### PR TITLE
Add support for skipping or expecting failure on a test

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -61,6 +61,9 @@ these allow substitutions (explained below).
   in the response body.
 * ``response_json_paths``: A dictionary of JSONPath rules paired with
   expected matches.
+* ``skip``: A string message which if set will cause the test to be
+  skipped with the provided message.
+* ``xfail``: If ``True`` expect this test to fail but run it anyway.
 
 There are a small number of magical variables that can be used to make
 reference to the state of a current test or the one just prior. These

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -13,7 +13,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-"""A single HTTP request reprensented as a subclass of ``unittest.TestCase``
+"""A single HTTP request represented as a subclass of ``unittest.TestCase``
 
 The test case encapsulates the request headers and body and expected
 response headers and body. When the test is run an HTTP request is

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -54,12 +54,13 @@ BASE_TEST = {
     'response_strings': None,
     'response_json_paths': None,
     'data': '',
+    'xfail': False,
+    'skip': '',
 }
 
 
 class TestBuilder(type):
-    """Metaclass to munge a dynamically created test.
-    """
+    """Metaclass to munge a dynamically created test."""
 
     required_attributes = {'has_run': False}
 
@@ -141,7 +142,7 @@ def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
                                  % test_name)
 
         # Use metaclasses to build a class of the necessary type
-        # with relevant arguments.
+        # and name with relevant arguments.
         klass = TestBuilder(test_name, (case.HTTPTestCase,),
                             {'test_data': test,
                              'test_directory': test_directory,

--- a/gabbi/gabbits_intercept/failskip.yaml
+++ b/gabbi/gabbits_intercept/failskip.yaml
@@ -1,0 +1,14 @@
+#
+# Tests to confirm that xfail and skip are working.
+#
+
+tests:
+    
+    - name: wrong status
+      xfail: True
+      url: /
+      status: 404
+
+    - name: skip me
+      skip: Skipping for now because we can't do it
+      url: http://nowhere.example.com/house

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pbr>=0.6,!=0.7,<1.0
 six>=1.7.0
+testtools
 PyYAML
 httplib2
 jsonpath-rw

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Run the tests and confirm that the stuff we expect to skip or fail
+# does.
+
+GREP_FAIL_MATCH='expected failures=1'
+GREP_SKIP_MATCH='skips=1'
+
+python setup.py testr && \
+    testr last --subunit | subunit2pyunit 2>&1 | \
+    grep "${GREP_FAIL_MATCH}" && \
+    testr last | grep "${GREP_SKIP_MATCH}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py33,py34,pep8,limit
+envlist = py27,py33,py34,pep8,limit,failskip
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -22,6 +22,9 @@ commands =
 
 [testenv:limit]
 commands = {toxinidir}/test-limit.sh
+
+[testenv:failskip]
+commands = {toxinidir}/test-failskip.sh
 
 [testenv:cover]
 commands = python setup.py testr --coverage --testr-args="{posargs}"


### PR DESCRIPTION
This is needed because during the test writing process there
are often _many_ things that ought to succeed but don't that are
beyond the scope of the immediate project. For example a framework
not properly returning a 405 when a method is not allowed, or
returning 405 but then not returning the Allow header.

This feature required switching the base test case from unittest to
testtools. The former has changed (in Python 3.4) the internals of how
expecting failure is handled and as a result making it work with
dynamically generated tests was proving extremely difficult.

An additional shell driven test is provided for coverage of
skip and fail.