### PR TITLE
Wrap the http request to trap WSGIAppError and reraise

### DIFF
--- a/gabbi/gabbits_intercept/self.yaml
+++ b/gabbi/gabbits_intercept/self.yaml
@@ -19,11 +19,11 @@ tests:
 
 - name: bogus method
   url: /
-  method: DIE
+  method: UNREAL
   status: 405
   response_headers:
       allow: GET, PUT, POST, DELETE, PATCH
-      x-gabbi-method: DIE
+      x-gabbi-method: UNREAL
       x-gabbi-url: $SCHEME://$NETLOC/
 
 - name: query returned
@@ -105,3 +105,9 @@ tests:
   xfail: true
   response_test:
       - 'CO"alpha": ["1"]'
+
+- name: test exception wrapper
+  desc: simple wsgi will raise exception
+  url: /
+  xfail: true
+  method: DIE

--- a/gabbi/simple_wsgi.py
+++ b/gabbi/simple_wsgi.py
@@ -51,6 +51,9 @@ class SimpleWsgi(object):
             ('X-Gabbi-url', request_url),
         ]
 
+        if request_method == 'DIE':
+            raise Exception('because you asked me to')
+
         if request_method not in METHODS:
             headers.append(
                 ('Allow', ', '.join(METHODS)))

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -2,7 +2,7 @@
 # Run the tests and confirm that the stuff we expect to skip or fail
 # does.
 
-GREP_FAIL_MATCH='expected failures=3'
+GREP_FAIL_MATCH='expected failures=4'
 GREP_SKIP_MATCH='skips=2'
 
 python setup.py testr && \


### PR DESCRIPTION
To create a strong boundary between the client and the server,
wsgi-intercept wraps exceptions raised in the intercepted app in a
WSGIAppError. In most situations this is a good thing. However if
gabbi is being used to do TDD against a nascent API this behavior
can obscure useful traceback information when there is a
catastrophic and untrapped exception in the server code.

To deal with this the WSGIAppError is caught and the contained
exception is reraised in all its glory to spew into STDERR for
debugging purposes.