### PR TITLE
Add a command line to to run yaml-tests from stdin.

### DIFF
--- a/docs/source/gabbi.rst
+++ b/docs/source/gabbi.rst
@@ -40,3 +40,19 @@ gabbi Package
     :members:
     :undoc-members:
     :show-inheritance:
+
+:mod:`runner` Module
+--------------------
+
+.. automodule:: gabbi.runner
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+:mod:`utils` Module
+-------------------
+
+.. automodule:: gabbi.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@
    host
    fixtures
    handlers
+   runner
    gabbi
 
 Gabbi
@@ -19,13 +20,16 @@ Gabbi
 Gabbi is a tool for running HTTP tests where requests and responses
 are expressed as declarations in a collection of YAML files.
 
-If you're not after the overview and just want to get on with it,
-see the :doc:`gabbi` documentation and the test files in the
-`source distribution`_.
-
 The name is derived from "gabby": excessively talkative. In a test
-environment this is a good thing. The "y" to an "i" is an
-optimization for any future backronyms.
+environment having visibility of what a test is actually doing is a
+good thing. The "y" to an "i" is an optimization for as yet to be
+determined backronyms such as: "Garrulous API Barrier Breaking
+Initiative" or "Glorious And Basic Beta Investigator". These
+are not good enough so the search continues.
+
+If you want to get straight to creating tests, look at the test
+files in the `source distribution`_ and :doc:`format`. A
+tutorial is in the works.
 
 .. _source distribution: https://github.com/cdent/gabbi
 
@@ -34,8 +38,7 @@ Purpose
 
 Gabbi works to bridge the gap between human readable YAML files (see
 :doc:`format` for details) that represent HTTP requests and expected
-responses and the obscured realm of Python-based, object-oriented unit
-tests in the style of the unittest module and its derivatives.
+responses and the rather complex world of automated testing.
 
 Each YAML file represents an ordered list of HTTP requests along with
 the expected responses. This allows a single file to represent a
@@ -56,15 +59,23 @@ These features mean that it is possible to create tests that are useful
 for both humans (as tools for learning, improving and developing APIs)
 and automated CI systems.
 
-Extended functionality, such as the use of `JSONPath`_ to query response
-bodies and reuse the prior response data in the current request,
-exists to make it easier to test relatively complex JSON-driven APIs,
-even those bold enough to lay claim to being fully RESTful with
-HATEOAS.
+Significant flexibility and power is available in the :doc:`format` to
+make it relatively straightforward to test existing complex APIs.
+This extended functionality includes the use of `JSONPath`_ to query
+response bodies and templating of test data to allow access to the prior
+HTTP response in the current request. For APIs which do not use JSON
+additional :doc:`handlers` can be created.
 
-This functionality should not be taken as license to write gloriously
-complex test files. If your API is so complex that it needs complex
+Care should be taken when using this functionality when you are
+creating a new API. If your API is so complex that it needs complex
 test files then you may wish to take that as a sign that your API
-itself too complex.
+itself too complex. One goal of gabbi is to encourage transparent
+and comprehensible APIs.
+
+Though gabbi is written in Python and under the covers uses
+``unittest`` data structures and processes, there is no requirement
+that the :doc:`host` be a Python-based service. Anything talking
+HTTP can be tested. A :doc:`runner` makes it possible to simply
+create YAML files and point them at a running server.
 
 .. _JSONPath: http://goessner.net/articles/JsonPath/

--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -1,0 +1,16 @@
+YAML Runner
+===========
+
+If there is a running web service that needs to be tested and
+creating a test loader with :meth:`~gabbi.driver.build_tests` is
+either inconvenient or overkill it is possible to run YAML test
+files directly from the command line with the console-script
+``gabbi-run``. It accepts YAML on ``stdin``, generates and runs
+tests and outputs a summary of the results.
+
+The provided YAML may not use custom :doc:`fixtures` but otherwise
+uses the default :doc:`format`. :doc:`host` information is either
+expressed directly in the YAML file or provided on the command
+line::
+
+    gabbi-run [host[:port]] < /my/test.yaml

--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -1,0 +1,59 @@
+# Copyright 2014, 2015 Red Hat
+#
+# Authors: Chris Dent <chdent@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import sys
+import yaml
+import unittest
+
+from . import driver
+
+
+def run():
+    """Run simple tests from STDIN.
+
+    This command provides a way to run a set of tests encoded in YAML that
+    is provided on STDIN. No fixtures are supported, so this is primarily
+    designed for use with real running services.
+
+    Host and port information may be provided in two different ways:
+
+    * In the URL value of the tests.
+    * In a `host` or `host:port` argument on the command line.
+
+    An example run might looks like this::
+
+        gabbi-run example.com:9999 < mytest.yaml
+
+    Output is formatted as unittest summary information.
+    """
+    try:
+        hostport = sys.argv[1]
+        if ':' in hostport:
+            host, port = hostport.split(':')
+        else:
+            host = hostport
+            port = None
+    except IndexError:
+        host, port = 'stub', None
+    loader = unittest.defaultTestLoader
+    data = yaml.safe_load(sys.stdin.read())
+    suite = driver.test_suite_from_yaml(loader, 'input', data, '.',
+                                        host, port, None, None)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+
+
+if __name__ == '__main__':
+    run()

--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -52,7 +52,8 @@ def run():
     data = yaml.safe_load(sys.stdin.read())
     suite = driver.test_suite_from_yaml(loader, 'input', data, '.',
                                         host, port, None, None)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,7 @@ packages =
 all_files = 1
 build-dir = docs/build
 source-dir = docs/source
+
+[entry_points]
+console_scripts =
+    gabbi-run = gabbi.runner:run


### PR DESCRIPTION
A console-script reads stdin and generates a TestSuite to be run.
This can be used as a nice way to test running services without any
test-building-in-python requirements.