### PR TITLE
Add verbose reporting of request and response

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -46,6 +46,8 @@ these allow substitutions (explained below).
 * ``ssl``: Make this request use SSL? Defaults to ``False``. This only
   comes into play if the ``url`` does not provide a scheme (see
   :doc:`host` for more info).
+* ``verbose``: If ``True`` print a representation of the current
+  request and response to ``stdout``. Defaults to ``False``.
 * ``redirects``: If ``True`` automatically follow redirects. Defaults
   to ``False``.
 * ``request_headers``: A dictionary of key-value pairs representing

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -20,6 +20,8 @@ response headers and body. When the test is run an HTTP request is
 made using httplib2. Assertions are made against the reponse.
 """
 
+from __future__ import print_function
+
 import copy
 import functools
 import json
@@ -49,6 +51,7 @@ REPLACERS = [
 BASE_TEST = {
     'name': '',
     'desc': '',
+    'verbose': False,
     'ssl': False,
     'redirects': False,
     'method': 'GET',
@@ -298,6 +301,13 @@ class HTTPTestCase(testcase.TestCase):
         self.http.follow_redirects = False
         if test['redirects']:
             self.http.follow_redirects = True
+
+        # Print some information about this request is asked.
+        if test['verbose']:
+            print('\n###########################')
+            print('%s %s' % (method, full_url))
+            for key in headers:
+                print('%s: %s' % (key, headers[key]))
 
         self._run_request(full_url, method, headers, body)
         self._assert_response()

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -34,13 +34,13 @@ import os
 from unittest import suite
 import uuid
 
-import httplib2
 import six
 import yaml
 
 from gabbi import case
 from gabbi import handlers
 from gabbi import suite as gabbi_suite
+from gabbi import utils
 
 RESPONSE_HANDLERS = [
     handlers.StringResponseHandler,
@@ -159,11 +159,12 @@ def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
 
         # Use metaclasses to build a class of the necessary type
         # and name with relevant arguments.
+        http_class = utils.get_http(verbose=test['verbose'])
         klass = TestBuilder(test_name, (case.HTTPTestCase,),
                             {'test_data': test,
                              'test_directory': test_directory,
                              'fixtures': fixture_classes,
-                             'http': httplib2.Http(),
+                             'http': http_class,
                              'host': host,
                              'intercept': intercept,
                              'port': port,

--- a/gabbi/gabbits_intercept/self.yaml
+++ b/gabbi/gabbits_intercept/self.yaml
@@ -10,6 +10,7 @@ defaults:
 tests:
 - name: get simple page
   url: /
+  verbose: True
 
 - name: inheritance of defaults
   response_headers:

--- a/gabbi/utils.py
+++ b/gabbi/utils.py
@@ -15,6 +15,33 @@
 # under the License.
 """Utility functions grab bag."""
 
+from __future__ import print_function
+
+import httplib2
+
+
+class VerboseHttp(httplib2.Http):
+    """A subclass of Http that verbosely reports on activity."""
+
+    def _request(self, conn, host, absolute_uri, request_uri, method, body,
+                 headers, redirections, cachekey):
+        """Display request parameters before requesting."""
+
+        print('\n%s %s\nHost: %s' % (method, request_uri, host))
+        for key in headers:
+            print('%s: %s' % (key, headers[key]))
+
+        (response, content) = httplib2.Http._request(
+            self, conn, host, absolute_uri, request_uri, method, body,
+            headers, redirections, cachekey
+        )
+
+        print()
+        for key in response.dict:
+            print('%s: %s' % (key, response.dict[key]))
+
+        return (response, content)
+
 
 def decode_content(response, content):
     """Decode content to a proper string."""
@@ -31,6 +58,13 @@ def decode_content(response, content):
         return content.decode(charset)
     else:
         return content
+
+
+def get_http(verbose=False):
+    """Return an Http class for making requests."""
+    if verbose:
+        return VerboseHttp()
+    return httplib2.Http()
 
 
 def not_binary(content_type):


### PR DESCRIPTION
In normal testing setups it is not possible to see the requests and
responses being made. If a test is set to 'verbose: True' then the
test request info and the httplib2 request and response data will be
produced to STDOUT.