### PR TITLE
Adding a tox environment for docs

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ tox
 testrepository
 coverage
 hacking
+sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py33,py34,pep8,limit,failskip
+envlist = py27,py33,py34,pep8,limit,failskip,docs
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -28,6 +28,13 @@ commands = {toxinidir}/test-failskip.sh
 
 [testenv:cover]
 commands = python setup.py testr --coverage --testr-args="{posargs}"
+
+[testenv:docs]
+commands =
+    rm -rf doc/build
+    python setup.py build_sphinx
+whitelist_externals =
+    rm
 
 [flake8]
 ignore = H405,E126


### PR DESCRIPTION
This change adds a new tox environment for building the docs, it also
brings the sphinx package into the test requirements.

The docs can now be generated by typing `tox -e docs`.

* adding doc environment to tox.ini
* adding sphinx to test-requirements.txt