### PR TITLE
Add a poll key to allow requests that can loop until they pass or a limit is reached

### DIFF
--- a/docs/source/example.yaml
+++ b/docs/source/example.yaml
@@ -182,3 +182,27 @@ tests:
           $.abode: $RESPONSE['$.abode']
       response_headers:
           content-location: /$SCHEME://$NETLOC/
+
+# For APIs where resource creation is asynchronous it can be
+# necessary to poll for the resulting resource. First we create the
+# resource in one test. The next test uses the "poll" key to loop
+# with a delay for a set number of times.
+
+    - name: create asynch
+      url: /async_creator
+      method: POST
+      request_headers:
+          content-type: application/json
+      data:
+          name: jones
+          abode: bungalow
+      status: 202
+
+    - name: poll for created resource
+      url: $LOCATION
+      poll:
+          count: 10 # try up to ten times
+          delay: .5 # wait .5 seconds between each try
+      response_json_paths:
+          $.name: $RESPONSE['$.name']
+          $.abode: $RESPONSE['$.abode']

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -66,6 +66,15 @@ these allow substitutions (explained below).
   in the response body.
 * ``response_json_paths``: A dictionary of JSONPath rules paired with
   expected matches.
+* ``poll``: A dictionary of two keys:
+
+  * ``count``: An integer stating the number of times to attempt
+    this test before giving up.
+  * ``delay``: A floating point number of seconds to delay between
+    attemmpts.
+
+  This makes it possible to poll for a resource created via an
+  asynchronous request. Use with caution.
 
 The ``response_*`` items are examples of Response Handlers. Additional
 handlers may be created by test authors for specific use cases. See

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -315,11 +315,10 @@ class HTTPTestCase(testcase.TestCase):
                 print('%s: %s' % (key, headers[key]))
 
         if test['poll']:
-            count = test['poll'].get('count', 0)
+            count = test['poll'].get('count', 1)
             delay = test['poll'].get('delay', 1)
             failure = None
             while count:
-                print('counting: %s' % count, file=sys.stderr)
                 try:
                     self._run_request(full_url, method, headers, body)
                     self._assert_response()

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -26,6 +26,7 @@ import json
 import os
 import re
 import sys
+import time
 
 import jsonpath_rw
 import six
@@ -59,6 +60,7 @@ BASE_TEST = {
     'data': '',
     'xfail': False,
     'skip': '',
+    'poll': {},
 }
 
 
@@ -312,8 +314,28 @@ class HTTPTestCase(testcase.TestCase):
             for key in headers:
                 print('%s: %s' % (key, headers[key]))
 
-        self._run_request(full_url, method, headers, body)
-        self._assert_response()
+        if test['poll']:
+            count = test['poll'].get('count', 0)
+            delay = test['poll'].get('delay', 1)
+            failure = None
+            while count:
+                print('counting: %s' % count, file=sys.stderr)
+                try:
+                    self._run_request(full_url, method, headers, body)
+                    self._assert_response()
+                    failure = None
+                    break
+                except AssertionError as exc:
+                    failure = exc
+
+                count -= 1
+                time.sleep(delay)
+
+            if failure:
+                raise failure
+        else:
+            self._run_request(full_url, method, headers, body)
+            self._assert_response()
 
     def _scheme_replace(self, message):
         """Replace $SCHEME with the current protocol."""

--- a/gabbi/gabbits_intercept/poll.yaml
+++ b/gabbi/gabbits_intercept/poll.yaml
@@ -1,5 +1,5 @@
 #
-# Test waiting on slow responses.
+# Test polling until a desired response.
 #
 
 tests:
@@ -11,9 +11,8 @@ tests:
     # assertion failure.
     - name: poller
       url: /poller
-      verbose: True
       poll:
-          delay: 1
+          delay: .01
           count: 8
 
     # This one we expect to fail because /poller in SimpleWSGI only
@@ -21,7 +20,30 @@ tests:
     - name: poller fail
       url: /poller
       xfail: True
+      poll:
+          delay: .01
+          count: 3
+
+    # Confirm that $LOCATION and $RESPONSE behave in poll.
+    - name: create a thing
+      url: /poller?count=2&x=1&y=2
+      method: POST
+      request_headers:
+          content-type: application/json
+      poll:
+          count: 3
+          delay: .01
+      response_json_paths:
+          $.x[0]: '1'
+          $.y[0]: '2'
+
+
+    - name: loop location
+      url: $LOCATION
       verbose: True
       poll:
-          delay: 1
           count: 3
+          delay: .01
+      response_json_paths:
+          $.x[0]: $RESPONSE['$.x[0]']
+          $.y[0]: $RESPONSE['$.y[0]']

--- a/gabbi/gabbits_intercept/poll.yaml
+++ b/gabbi/gabbits_intercept/poll.yaml
@@ -1,0 +1,12 @@
+#
+# Test waiting on slow responses.
+#
+
+tests:
+
+    - name: poller
+      url: /poller
+      verbose: True
+      poll:
+          delay: 1
+          count: 8

--- a/gabbi/gabbits_intercept/poll.yaml
+++ b/gabbi/gabbits_intercept/poll.yaml
@@ -4,9 +4,24 @@
 
 tests:
 
+    # This will attempt /poller up to 8 times waiting for a status
+    # 200, waiting one second between attempts. If the test passes
+    # during any attempt then we move on to the next test.
+    # If no pass happens, the last failure is raised as the
+    # assertion failure.
     - name: poller
       url: /poller
       verbose: True
       poll:
           delay: 1
           count: 8
+
+    # This one we expect to fail because /poller in SimpleWSGI only
+    # counts up to five attempts.
+    - name: poller fail
+      url: /poller
+      xfail: True
+      verbose: True
+      poll:
+          delay: 1
+          count: 3

--- a/gabbi/simple_wsgi.py
+++ b/gabbi/simple_wsgi.py
@@ -78,7 +78,7 @@ class SimpleWsgi(object):
 
         if request_url.startswith('/poller'):
             if CURRENT_POLL == 0:
-                CURRENT_POLL = query_data.get('count', [5])[0]
+                CURRENT_POLL = int(query_data.get('count', [5])[0])
                 start_response('400 Bad Reqest', [])
                 return []
             else:

--- a/gabbi/simple_wsgi.py
+++ b/gabbi/simple_wsgi.py
@@ -76,9 +76,7 @@ class SimpleWsgi(object):
                         query_data = body_data
             headers.append(('Location', full_request_url))
 
-        import sys
         if request_url.startswith('/poller'):
-            print('CURRENT_POLL %s'% CURRENT_POLL, file=sys.stderr)
             if CURRENT_POLL == 0:
                 CURRENT_POLL = query_data.get('count', [5])[0]
                 start_response('400 Bad Reqest', [])

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -2,7 +2,7 @@
 # Run the tests and confirm that the stuff we expect to skip or fail
 # does.
 
-GREP_FAIL_MATCH='expected failures=4'
+GREP_FAIL_MATCH='expected failures=5'
 GREP_SKIP_MATCH='skips=2'
 
 python setup.py testr && \


### PR DESCRIPTION
The "limit" is a combination of `count` and `delay` keys.

`example.yaml` shows an example (as ya do) and there are simple docs in format.rst

The main reason for creating this feature is to deal with resource generators that return 202 and follow up queries to see if the data landed need to wait.