### PR TITLE
Ensure response header comparisons are case-insensitive

### DIFF
--- a/gabbi/handlers.py
+++ b/gabbi/handlers.py
@@ -120,6 +120,8 @@ class HeadersResponseHandler(ResponseHandler):
     test_key_value = {}
 
     def action(self, test, header, value):
+        header = header.lower()  # case-insensitive comparison
+
         response = test.response
         header_value = test.replace_template(value)
 

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -94,10 +94,16 @@ class HandlersTest(unittest.TestCase):
 
     def test_response_headers(self):
         handler = handlers.HeadersResponseHandler(self.test_class)
+        self.test.response = {'content-type': 'text/plain'}
+
         self.test.test_data = {'response_headers': {
             'content-type': 'text/plain',
         }}
-        self.test.response = {'content-type': 'text/plain'}
+        self._assert_handler(handler)
+
+        self.test.test_data = {'response_headers': {
+            'Content-Type': 'text/plain',
+        }}
         self._assert_handler(handler)
 
     def test_response_headers_regex(self):


### PR DESCRIPTION
fixes #55 

I'm not sure reusing `handler` and `self.test` in the test is appropriate, but I wanted to avoid repetitive boilerplate (for readability)