### PR TITLE
Allow single or double quotes in replacers

### DIFF
--- a/gabbi/gabbits_intercept/backref.yaml
+++ b/gabbi/gabbits_intercept/backref.yaml
@@ -16,7 +16,7 @@ tests:
       location: $SCHEME://$NETLOC/posterchild
 
 - name: post some more json
-  url: $RESPONSE['link']
+  url: $RESPONSE["link"]
   request_headers:
       content-type: application/json
   method: POST
@@ -26,7 +26,7 @@ tests:
      d:
        z: $RESPONSE['b']
   response_json_paths:
-     a: $RESPONSE['a']
+     a: $RESPONSE["a"]
      c: /v2
      d:
        z: $RESPONSE['b']
@@ -43,6 +43,22 @@ tests:
        "c": "$RESPONSE['c']"}
   response_strings:
       - '"a": "$RESPONSE[''a'']"'
+      - '"c": "/v2"'
+  response_headers:
+     location: $SCHEME://$NETLOC$RESPONSE['c']
+     x-gabbi-url: $SCHEME://$NETLOC/v2
+     content-type: $HEADERS['content-type']
+
+- name: post even more json quote different
+  url: $RESPONSE["c"]
+  request_headers:
+      content-type: application/json
+  method: POST
+  data: |
+      {"a": "$RESPONSE["a"]",
+       "c": "$RESPONSE["c"]"}
+  response_strings:
+      - '"a": "$RESPONSE["a"]"'
       - '"c": "/v2"'
   response_headers:
      location: $SCHEME://$NETLOC$RESPONSE['c']

--- a/gabbi/tests/test_replacers.py
+++ b/gabbi/tests/test_replacers.py
@@ -44,3 +44,8 @@ class EnvironReplaceTest(testtools.TestCase):
 
         os.environ['moo'] = "cow"
         self.assertEqual("cow", http_case._environ_replace(message))
+
+        message = '$ENVIRON["moo"]'
+
+        os.environ['moo'] = "True"
+        self.assertEqual(True, http_case._environ_replace(message))


### PR DESCRIPTION
Such that ENVIRON['foo'] and ENVIRON["foo"] will both work but
ENVIRON["foo'] will not.

In the process regex handling is refactored to allow each of the
replaces to use the same basic regex and named groups rather than
numbered. Should allow for future adjustments like this to be less
painful.

Fixes #58