### PR TITLE
Get rid of testtools and adjust gabbi.report accordingly

### DIFF
--- a/gabbi/reporter.py
+++ b/gabbi/reporter.py
@@ -72,16 +72,26 @@ class ConciseTestResult(TextTestResult):
         desc = test.test_data.get('desc', None)
         return ': '.join((name, desc)) if desc else name
 
+    def _exc_info_to_string(self, err, test):
+        """Override exception to string handling
+
+        The default does too much. We don't want doctoring. We want
+        information!
+        """
+        return err
+
     def printErrorList(self, flavor, errors):
         for test, err in errors:
             self.stream.writeln('%s: %s' % (flavor, self.getDescription(test)))
-            # extract details from traceback
-            # XXX: fugly workaround, for lack of a better solution
-            details = str(err)
-            details = details.strip().splitlines()[-1]  # traceback's last line
-            if ':' in details:
-                details = details.split(':', 1)[1]  # discard exception name
-            self.stream.writeln('\t%s' % details.strip())
+            self.stream.writeln('%s:%s:%s' % (err[0], err[1][0][:70], err[2]))
+# The rest is left as an exercise for FND
+#             details = err.strip().splitlines()[-1]  # traceback's last line
+#             if ':' in details:
+#                 details = details.split(':', 1)[1]  # discard exception name
+#             if True:  # some kind of flag here?
+#                 self.stream.writeln('\t%s' % details[:70].strip())
+#             else:
+#                 self.stream.writeln('%s' % err)
 
 
 class ConciseTestRunner(TextTestRunner):

--- a/gabbi/reporter.py
+++ b/gabbi/reporter.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import traceback
 from unittest import TextTestResult
 from unittest import TextTestRunner
 
@@ -82,16 +83,12 @@ class ConciseTestResult(TextTestResult):
 
     def printErrorList(self, flavor, errors):
         for test, err in errors:
+            # err[0] is the type of exception
+            # err[1] is the args of the exception
+            # err[3] is the traceback, not currently used
             self.stream.writeln('%s: %s' % (flavor, self.getDescription(test)))
-            self.stream.writeln('%s:%s:%s' % (err[0], err[1][0][:70], err[2]))
-# The rest is left as an exercise for FND
-#             details = err.strip().splitlines()[-1]  # traceback's last line
-#             if ':' in details:
-#                 details = details.split(':', 1)[1]  # discard exception name
-#             if True:  # some kind of flag here?
-#                 self.stream.writeln('\t%s' % details[:70].strip())
-#             else:
-#                 self.stream.writeln('%s' % err)
+            message = str(err[1]).replace('\n', '\\r')
+            self.stream.writeln('\t%s' % message)
 
 
 class ConciseTestRunner(TextTestRunner):

--- a/gabbi/reporter.py
+++ b/gabbi/reporter.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import traceback
 from unittest import TextTestResult
 from unittest import TextTestRunner
 

--- a/gabbi/tests/test_fixtures.py
+++ b/gabbi/tests/test_fixtures.py
@@ -14,7 +14,7 @@
 """
 
 import mock
-import testtools
+import unittest
 
 from gabbi import fixture
 
@@ -34,7 +34,7 @@ class FakeFixture(fixture.GabbiFixture):
         self.mock.stop()
 
 
-class FixtureTest(testtools.TestCase):
+class FixtureTest(unittest.TestCase):
 
     def setUp(self):
         super(FixtureTest, self).setUp()

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -13,7 +13,6 @@
 """Test response handlers.
 """
 
-from testtools import matchers
 import unittest
 
 from gabbi import case
@@ -120,7 +119,6 @@ class HandlersTest(unittest.TestCase):
         self.test.response = {'content-type': 'application/json'}
         with self.assertRaises(AssertionError) as failure:
             self._assert_handler(handler)
-        self.assertIsInstance(failure.exception, matchers.MismatchError)
         self.assertIn("Expect header content-type with value text/plain,"
                       " got application/json",
                       str(failure.exception))

--- a/gabbi/tests/test_replacers.py
+++ b/gabbi/tests/test_replacers.py
@@ -15,12 +15,12 @@
 
 import os
 
-import testtools
+import unittest
 
 from gabbi import case
 
 
-class EnvironReplaceTest(testtools.TestCase):
+class EnvironReplaceTest(unittest.TestCase):
 
     def test_environ_boolean(self):
         """Environment variables are always strings

--- a/gabbi/tests/test_utils.py
+++ b/gabbi/tests/test_utils.py
@@ -13,12 +13,12 @@
 """Test functions from the utils module.
 """
 
-import testtools
+import unittest
 
 from gabbi import utils
 
 
-class UtilsTest(testtools.TestCase):
+class UtilsTest(unittest.TestCase):
 
     BINARY_TYPES = [
         'image/png',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pbr
 six
-testtools
 PyYAML
 httplib2
 jsonpath-rw


### PR DESCRIPTION
testtools has too much magic, making it difficult to have direct access to test error information. Having access to that test error information is required to make the output from gabbi-run useful.

The change attempts to replicate the existing behavior of gabbi-run but add no more. That should be for later efforts.

@FND if you're able to confirm the "existing behavior" part then we can probably merge.

