### PR TITLE
NETLOC shouldn't have default port

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -252,7 +252,9 @@ class HTTPTestCase(unittest.TestCase):
         netloc = self.host
 
         if not url_scheme:
-            if self.port:
+            if (self.port
+                    and not (self.port == 443 and ssl)
+                    and not (self.port == 80 and not ssl)):
                 netloc = '%s:%s' % (self.host, self.port)
             if ssl:
                 scheme = 'https'


### PR DESCRIPTION
Hi,

If scheme in http and port 80, NETLOC shouldn't have port set.

Same for https


Cheers,