### PR TITLE
Add query_parameters field

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -39,6 +39,9 @@ Many of these items allow substitutions (explained below).
   fully qualified URL (with host and scheme). If not qualified the
   test builder will be responsible for determining host and scheme.
   **Required**
+* ``query_parameters``: An optional dictionary of query parameters
+  that will be added to the ``url``. If there is an existing set of
+  query parameters they wil be extended.
 * ``method``: The request method to use. Defaults to ``GET``.
 * ``status``: The expected response status code. The default is
   ``200``. If necessary you may indicate multiple response codes
@@ -111,6 +114,7 @@ character must be used at both ends.
 All of these variables may be used in all of the following fields:
 
 * ``url``
+* ``query_parameters``
 * ``data``
 * ``request_headers``
 * ``response_strings``

--- a/gabbi/gabbits_intercept/queryparams.yaml
+++ b/gabbi/gabbits_intercept/queryparams.yaml
@@ -1,0 +1,57 @@
+#
+# As a convenience a URL can be augmented with structured declaration
+# of query parameters.
+#
+
+tests:
+
+    - name: simple param
+      url: /foo
+      query_parameters:
+          bar: 1
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foo?bar=1
+
+    - name: joined params
+      url: /foo?cow=moo
+      query_parameters:
+          bar: 1
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foo?cow=moo&bar=1
+
+    - name: multi params
+      url: /foo
+      request_headers:
+          accept: application/json
+      query_parameters:
+          bar:
+            - 1
+            - 2 
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foo?bar=1&bar=2
+          content-type: application/json
+      response_json_paths:
+          $.bar[0]: "1"
+          $.bar[1]: "2"
+
+    - name: replacers in params
+      url: /foo
+      query_parameters:
+          fromjson: $RESPONSE['$.bar[0]']
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foo?fromjson=1
+
+    - name: unicode
+      url: /foo
+      query_parameters:
+          snowman: ☃
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foo?snowman=%E2%98%83
+
+    - name: url in param
+      url: /foo
+      query_parameters:
+          redirect: http://example.com/treehouse?secret=true&password=hello
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foo?redirect=http%3A%2F%2Fexample.com%2Ftreehouse%3Fsecret%3Dtrue%26password%3Dhello
+

--- a/gabbi/handlers.py
+++ b/gabbi/handlers.py
@@ -106,8 +106,8 @@ class JSONResponseHandler(ResponseHandler):
             raise AssertionError('json path %s cannot match %s' %
                                  (path, test.json_data))
         expected = test.replace_template(value)
-        test.assertEqual(expected, match, 'Unable to match %s as %s'
-                         % (path, expected))
+        test.assertEqual(expected, match, 'Unable to match %s as %s in %s'
+                         % (path, expected, test.json_data))
 
 
 class HeadersResponseHandler(ResponseHandler):

--- a/gabbi/tests/test_parse_url.py
+++ b/gabbi/tests/test_parse_url.py
@@ -26,9 +26,11 @@ class UrlParseTest(unittest.TestCase):
 
     @staticmethod
     def make_test_case(host, port=8000, prefix=''):
-        # attributes used are port, prefix and host and they must
-        # be set manually here, due to metaclass magics elsewhere
+        # Attributes used are port, prefix and host and they must
+        # be set manually here, due to metaclass magics elsewhere.
+        # test_data must have a base value.
         http_case = case.HTTPTestCase('test_request')
+        http_case.test_data = case.BASE_TEST
         http_case.host = host
         http_case.port = port
         http_case.prefix = prefix


### PR DESCRIPTION
This adds a query_parameters field which can be used to add query
parameters to the url of the test in which it is used. It is a dict in
a form suitable for being passed to the urlencode() method.

This change is cumbersome because urlencoded in python2 and 3 have
different behaviors: In python2 a utf-8 encoded string is required.
In 3 it will figure out the right thing. So we here we just encode.

We also need to deal with the fact that a numeral in YAML will be
provided to Python as a numeric value and we need to stringify that in
a version independent fashion.