### PR TITLE
Gabbi run argparse

### DIFF
--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -15,14 +15,22 @@ line::
 
     gabbi-run [host[:port]] < /my/test.yaml
 
+or::
+
+    gabbi-run http://host:port < /my/test.yaml
+
 To facilitate using the same tests against the same application mounted
 in different locations in a WSGI server, a ``prefix`` may be provided
 as a second argument::
 
     gabbi-run host[:port] [prefix] < /my/test.yaml
 
+or in the target URL::
+
+    gabbi-run http://host:port/prefix < /my/test.yaml
+
 The value of prefix will be prepended to the path portion of URLs that
 are not fully qualified.
 
-If a ``-x`` argument is provided then ``gabbi-run`` will "fail fast"
-exiting after the first test failure.
+If a ``-x`` or ``--failfast`` argument is provided then ``gabbi-run`` will
+"fail fast", exiting after the first test failure.

--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -16,6 +16,8 @@ import sys
 import unittest
 import yaml
 
+from six.moves.urllib import parse as urlparse
+
 from gabbi import case
 from gabbi import driver
 from gabbi.reporter import ConciseTestRunner
@@ -28,21 +30,30 @@ def run():
     is provided on STDIN. No fixtures are supported, so this is primarily
     designed for use with real running services.
 
-    Host and port information may be provided in two different ways:
+    Host and port information may be provided in three different ways:
 
     * In the URL value of the tests.
     * In a `host` or `host:port` argument on the command line.
+    * In a URL on the command line.
 
     An example run might looks like this::
 
         gabbi-run example.com:9999 < mytest.yaml
 
+    or::
+
+        gabbi-run http://example.com:999 < mytest.yaml
+
     It is also possible to provide a URL prefix which can be useful if the
-    target application might be mounted in different locations. An example:
+    target application might be mounted in different locations. An example::
 
         gabbi-run example.com:9999 /mountpoint < mytest.yaml
 
-    Use `-x` to abort after the first error or failure:
+    or::
+
+        gabbi-run http://example.com:9999/mountpoint < mytest.yaml
+
+    Use `-x` or `--failfast` to abort after the first error or failure:
 
         gabbi-run -x example.com:9999 /mountpoint < mytest.yaml
 
@@ -50,19 +61,37 @@ def run():
     """
 
     parser = argparse.ArgumentParser(description='Run gabbi tests from STDIN')
-    parser.add_argument('target',
-                        help='The primary host and port, : separated')
-    parser.add_argument('prefix', nargs='?', default=None,
-                        help='URL prefix where app is mounted')
-    parser.add_argument('-x', '--failfast', help='Exit on first failure',
-                        action='store_true')
+    parser.add_argument(
+        'target',
+        help='A fully qualified URL (with optional path as prefix) '
+             'to the primary target or a host and port, : separated'
+    )
+    parser.add_argument(
+        'prefix',
+        nargs='?', default=None,
+        help='Path prefix where target app is mounted. Only used when '
+             'target is of the form host[:port]'
+    )
+    parser.add_argument(
+        '-x', '--failfast',
+        help='Exit on first failure',
+        action='store_true'
+    )
 
     args = parser.parse_args()
 
-    if ':' in args.target:
+    split_url = urlparse.urlsplit(args.target)
+    if split_url.scheme:
+        target = split_url.netloc
+        prefix = split_url.path
+    else:
+        target = args.target
+        prefix = args.prefix
+
+    if ':' in target:
         host, port = args.target.split(':')
     else:
-        host = args.target
+        host = target
         port = None
 
     loader = unittest.defaultTestLoader
@@ -74,7 +103,7 @@ def run():
     data = yaml.safe_load(sys.stdin.read())
     suite = driver.test_suite_from_yaml(loader, 'input', data, '.',
                                         host, port, None, None,
-                                        prefix=args.prefix)
+                                        prefix=prefix)
     result = ConciseTestRunner(verbosity=2, failfast=args.failfast).run(suite)
     sys.exit(not result.wasSuccessful())
 


### PR DESCRIPTION
Add support for using argparse with gabbi-run so that it produces some reasonable help and can take a URL as the target (instead of host[:port] [/prefix]).

/cc @FND, @jasonamyers 