### PR TITLE
added optional shortcut for specifying HTTP method and URL

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -3,13 +3,20 @@ Test Format
 
 Gabbi tests are expressed in YAML containing an HTTP request and an
 expected response. Each YAML file is an ordered sequence of requests.
-The bare minimum YAML file for a single request is::
+A minimal YAML file for a single request is::
 
     tests:
        - name: the name of a test
+         GET: /
+
+This is :ref:`short <method-shortcut>` for::
+
+    tests:
+       - name: the name of a test
+         method: GET
          url: /
 
-This will make a request to ``/`` on whatever the configured
+This will make a ``GET`` request to ``/`` on whatever the configured
 :doc:`host` is. The test will pass if the status of the HTTP response
 is ``200``.
 
@@ -89,6 +96,21 @@ Many of these items allow substitutions (explained below).
 
   This makes it possible to poll for a resource created via an
   asynchronous request. Use with caution.
+
+.. _method-shortcut:
+
+Note that it's possible to combine ``method`` and ``url`` into a single
+statement by exchanging the ``url`` key for the actual method::
+
+    method: PATCH
+    url: /
+
+corresponds to::
+
+    PATCH: /
+
+Any uppercase key is considered an HTTP method, there is no pre-defined
+list of approved methods.
 
 The ``response_*`` items are examples of Response Handlers. Additional
 handlers may be created by test authors for specific use cases. See

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -234,6 +234,10 @@ def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
 
 
 def _validate_defaults(default_dict):
+    """Ensure test presets are acceptable
+
+    Raises GabbiFormatError for invalid settings.
+    """
     if [key for key in default_dict if _is_method_shortcut(key)]:
         raise GabbiFormatError(
             '"METHOD: url" pairs not allowed in defaults')

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -187,7 +187,7 @@ def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
         # use uppercase keys as HTTP method
         method_key = None
         for key, val in six.iteritems(test):
-            if key.isupper():
+            if _is_method_shortcut(key):
                 if method_key:
                     raise GabbiFormatError(
                         'duplicate method/URL directive in "%s"' %
@@ -234,7 +234,11 @@ def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
 
 
 def _validate_defaults(default_dict):
-    if [key for key in default_dict if key.isupper()]:
+    if [key for key in default_dict if _is_method_shortcut(key)]:
         raise GabbiFormatError(
             '"METHOD: url" pairs not allowed in defaults')
     return default_dict
+
+
+def _is_method_shortcut(key):
+    return key.isupper()

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -178,6 +178,21 @@ def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
                 raise GabbiFormatError(
                     'malformed test chunk "%s": %s' % (test_datum, exc))
 
+        # use uppercase keys as HTTP method
+        method_key = None
+        for key, val in six.iteritems(test):
+            if key.isupper():
+                if method_key:
+                    raise GabbiFormatError(
+                        'duplicate method/URL directive in "%s"' %
+                        test_base_name)
+
+                test['method'] = key
+                test['url'] = val
+                method_key = key
+        if method_key:
+            del test[method_key]
+
         if not test['name']:
             raise GabbiFormatError('Test name missing in a test in %s.'
                                    % test_base_name)

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -233,15 +233,15 @@ def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
     return file_suite
 
 
-def _validate_defaults(default_dict):
+def _validate_defaults(defaults):
     """Ensure test presets are acceptable
 
     Raises GabbiFormatError for invalid settings.
     """
-    if [key for key in default_dict if _is_method_shortcut(key)]:
+    if [key for key in defaults if _is_method_shortcut(key)]:
         raise GabbiFormatError(
             '"METHOD: url" pairs not allowed in defaults')
-    return default_dict
+    return defaults
 
 
 def _is_method_shortcut(key):

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -234,7 +234,7 @@ def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
 
 
 def _validate_defaults(defaults):
-    """Ensure test presets are acceptable
+    """Ensure default test settings are acceptable
 
     Raises GabbiFormatError for invalid settings.
     """

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -238,7 +238,7 @@ def _validate_defaults(defaults):
 
     Raises GabbiFormatError for invalid settings.
     """
-    if [key for key in defaults if _is_method_shortcut(key)]:
+    if any(_is_method_shortcut(key) for key in defaults):
         raise GabbiFormatError(
             '"METHOD: url" pairs not allowed in defaults')
     return defaults

--- a/gabbi/gabbits_intercept/method_shortcut.yaml
+++ b/gabbi/gabbits_intercept/method_shortcut.yaml
@@ -1,0 +1,40 @@
+defaults:
+    POST: /somewhere
+
+tests:
+- name: defaults check
+  data:
+      cow: barn
+  request_headers:
+      content-type: application/json
+  response_json_paths:
+      $.cow: barn
+
+- name: altered defaults
+  url: /somewhere?chicken=coop
+  data:
+      cow: barn
+  request_headers:
+      content-type: application/json
+  response_json_paths:
+      $.cow: barn
+      $.chicken[0]: coop
+
+- name: overridden defaults
+  GET: /
+  ssl: True
+  response_headers:
+      x-gabbi-url: https://$NETLOC/
+
+- name: arbitrary method
+  IMAGINARY: /
+  status: 405
+  response_headers:
+      allow: GET, PUT, POST, DELETE, PATCH
+      x-gabbi-method: IMAGINARY
+      x-gabbi-url: $SCHEME://$NETLOC/
+
+- name: duplicate shortcut
+  GET: /
+  POST: /
+  xfail: true

--- a/gabbi/gabbits_intercept/method_shortcut.yaml
+++ b/gabbi/gabbits_intercept/method_shortcut.yaml
@@ -1,8 +1,7 @@
-defaults:
-    POST: /somewhere
 
 tests:
-- name: defaults check
+- name: simple POST
+  POST: /somewhere
   data:
       cow: barn
   request_headers:
@@ -10,8 +9,8 @@ tests:
   response_json_paths:
       $.cow: barn
 
-- name: altered defaults
-  url: /somewhere?chicken=coop
+- name: POST with query
+  POST: /somewhere?chicken=coop
   data:
       cow: barn
   request_headers:
@@ -20,7 +19,7 @@ tests:
       $.cow: barn
       $.chicken[0]: coop
 
-- name: overridden defaults
+- name: simple GET
   GET: /
   ssl: True
   response_headers:
@@ -34,7 +33,10 @@ tests:
       x-gabbi-method: IMAGINARY
       x-gabbi-url: $SCHEME://$NETLOC/
 
-- name: duplicate shortcut
-  GET: /
-  POST: /
-  xfail: true
+# Can't do this because format validation is during test generation not
+# test running. xfail only works during test running :(
+# See gabbi/tests/test_driver for a test of this.
+# - name: duplicate shortcut
+#   GET: /
+#   POST: /
+#   xfail: true

--- a/gabbi/tests/test_driver.py
+++ b/gabbi/tests/test_driver.py
@@ -111,3 +111,25 @@ class DriverTest(unittest.TestCase):
                                         'localhost', 80, None, None)
         self.assertIn("Invalid test keys used in test foo_simple:",
                       str(failure.exception))
+
+    def test_method_url_pair_format_error(self):
+        test_yaml = {'defaults': {'GET': '/foo'}, 'tests': []}
+        with self.assertRaises(driver.GabbiFormatError) as failure:
+            driver.test_suite_from_yaml(self.loader, 'foo', test_yaml, '.',
+                                        'localhost', 80, None, None)
+        self.assertIn('"METHOD: url" pairs not allowed in defaults',
+                      str(failure.exception))
+
+    def test_method_url_pair_duplication_format_error(self):
+        test_yaml = {'tests': [{
+            'GET': '/',
+            'POST': '/',
+            'name': 'duplicate methods',
+        }]}
+        with self.assertRaises(driver.GabbiFormatError) as failure:
+            driver.test_suite_from_yaml(self.loader, 'foo', test_yaml, '.',
+                                        'localhost', 80, None, None)
+        self.assertIn(
+            'duplicate method/URL directive in "foo_duplicate_methods"',
+            str(failure.exception)
+        )


### PR DESCRIPTION
before:

```yaml
method: GET
url: /foo
```

after:

```yaml
GET: /foo
```

Quoting from an earlier e-mail:

> The particular shortcut I proposed (`<verb>: <URL>`) would make the most
> fundamental part of an HTTP interaction more concise - plus it would
> more closely resemble the actual HTTP syntax.
>
> That's not just less to type, it might also improve readability (less
> repetitive noise) - assuming you're reasonably familiar with HTTP and
> its conventions (e.g. less common verbs like PATCH or OPTIONS might not
> be immediately recognizable as such, though the all-uppercase aspect is
> a decent hint).

----

⚠ work in progress

* [x] implementation
* [x] proper tests
* [x] documentation
