### PR TITLE
cli: target must be optional

### DIFF
--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -63,6 +63,7 @@ def run():
     parser = argparse.ArgumentParser(description='Run gabbi tests from STDIN')
     parser.add_argument(
         'target',
+        nargs='?', default='stub',
         help='A fully qualified URL (with optional path as prefix) '
              'to the primary target or a host and port, : separated'
     )


### PR DESCRIPTION
Since last release of gabbi enforce to set a target
on the command line, when it was not required before.

This have breaks the ceilometer integration tests that
query multiples API endpoints and don't set this target.

This change fixes that.