### PR TITLE
Extract parse url

### DIFF
--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -63,7 +63,7 @@ class TestBuilder(type):
 
 def build_tests(path, loader, host=None, port=8001, intercept=None,
                 test_loader_name=None, fixture_module=None,
-                response_handlers=None, prefix=None):
+                response_handlers=None, prefix=''):
     """Read YAML files from a directory to create tests.
 
     Each YAML file represents an ordered sequence of HTTP requests.
@@ -134,7 +134,7 @@ def test_update(orig_dict, new_dict):
 
 
 def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,
-                         host, port, fixture_module, intercept, prefix=None):
+                         host, port, fixture_module, intercept, prefix=''):
     """Generate a TestSuite from YAML data."""
 
     file_suite = gabbi_suite.GabbiSuite()

--- a/gabbi/tests/test_utils.py
+++ b/gabbi/tests/test_utils.py
@@ -84,7 +84,7 @@ class ExtractContentTypeTest(unittest.TestCase):
         self.assertEqual('utf-8', charset)
 
 
-class ColorozieTest(unittest.TestCase):
+class ColorizeTest(unittest.TestCase):
 
     def test__colorize_missing_color(self):
         """Make sure that choosing a non-existent color is safe."""
@@ -95,7 +95,7 @@ class ColorozieTest(unittest.TestCase):
         self.assertNotEqual('hello', message)
 
 
-class CreateUrlTest(unittest.TestCase):
+class CreateURLTest(unittest.TestCase):
 
     def test_create_url_simple(self):
         url = utils.create_url('/foo/bar', 'test.host.com')

--- a/gabbi/utils.py
+++ b/gabbi/utils.py
@@ -25,22 +25,22 @@ except NameError:  # Python 2
     ConnectionRefused = socket.error
 
 
-def create_url(base_url, host, port=None, prefix=None, ssl=False):
+def create_url(base_url, host, port=None, prefix='', ssl=False):
     """Given pieces of a path-based url, return a fully qualified url."""
-    parsed_url = urlparse.urlsplit(base_url)
     scheme = 'http'
     netloc = host
 
-    if (port and not (int(port) == 443 and ssl)
-            and not (int(port) == 80 and not ssl)):
+    if (port and not _port_follows_standard(port, ssl)):
         netloc = '%s:%s' % (host, port)
 
     if ssl:
         scheme = 'https'
 
+    parsed_url = urlparse.urlsplit(base_url)
     query_string = parsed_url.query
     path = parsed_url.path
 
+    # Guard against a prefix of None
     if prefix:
         path = '%s%s' % (prefix, path)
 
@@ -106,3 +106,9 @@ def _colorize(color, message):
         return getattr(colorama.Fore, color) + message + colorama.Fore.RESET
     except AttributeError:
         return message
+
+
+def _port_follows_standard(port, ssl):
+    """Return True if a standard port is using a non-standard ssl setting."""
+    port = int(port)
+    return (port == 443 and ssl) or (port == 80 and not ssl)


### PR DESCRIPTION
Extract _parse_url to its own utility method to allow it to be cleaned and for the query_parameters test element to be handled in its own method.

_parse_url was high complex according to the [radon](https://pypi.python.org/pypi/radon) tool.