### PR TITLE
attempted to clarify test and suite generation

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -50,7 +50,7 @@ REPLACERS = [
     'RESPONSE',
 ]
 
-# Empty test from which all others inherit
+# Basic test template determining both valid keys and default values
 BASE_TEST = {
     'name': '',
     'desc': '',


### PR DESCRIPTION
This is very much a light version of what I had planned [originally](https://github.com/cdent/gabbi/commit/415d76c2cfaffe04b9379bbe76af9eaff29ec6cb#commitcomment-13701857): I was considering introducing a set of intermediate classes (`GabbiTestDescriptor[Collection]`?) to encapsulate and shuffle around some of the logic in both `test_suite_from_yaml` and `TestMaker`, but I'm no longer convinced it's worth the effort (for now anyway).

Nevertheless, these leftovers of that aborted effort seem to better describe what's going on, if only by grouping related aspects within the existing function.

What still irks me is that `test_suite_from_yaml` actually doesn't have anything to do with YAML: It's merely processing a dictionary that once happened to originate from a YAML file. However, I couldn't figure out how to get around that without introducing new terminology (see above).