### PR TITLE
improved failure reporting for gabbi-run

### DIFF
--- a/gabbi/reporter.py
+++ b/gabbi/reporter.py
@@ -95,8 +95,9 @@ class ConciseTestResult(TextTestResult):
             # err[1] is the args of the exception
             # err[3] is the traceback, not currently used
             self.stream.writeln('%s: %s' % (flavor, self.getDescription(test)))
-            message = str(err[1]).replace('\n', '\\r')
-            self.stream.writeln('\t%s' % message)
+            message = str(err[1])
+            for line in message.splitlines():
+                self.stream.writeln('\t%s' % line)
 
 
 class ConciseTestRunner(TextTestRunner):


### PR DESCRIPTION
not extensively tested, but seems reasonably safe

before:

```
FAIL: input_service_registry
	'application/json-home' != 'application/json'\r- application/json-home\r?                 -----\r+ application/json\r : Expect header content-type with value application/json-home, got application/json
```

after:

```
FAIL: input_service_registry
	'application/json-home' != 'application/json'
	- application/json-home
	?                 -----
	+ application/json
	 : Expect header content-type with value application/json-home, got application/json
```

(that last line could probably improved, but let's leave that for later)
