### PR TITLE
Add response_forbidden_headers handler

### DIFF
--- a/docs/source/example.yaml
+++ b/docs/source/example.yaml
@@ -93,6 +93,14 @@ tests:
       response_headers:
           content-type: /application/json/
 
+# If a header must not be present in a response at all that can be
+# expressed in a test as follows.
+
+    - name: test forbidden headers
+      url: /resource
+      response_forbidden_headers:
+          - x-special-header
+
 # All of the above requests have defaulted to a "GET" method. When
 # using "POST", "PUT" or "PATCH", the "data" key provides the
 # request body.

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -122,45 +122,48 @@ Response Expectations
 
 .. table::
 
-   =======================  =====================================  ============
-   Key                      Description                            Notes
-   =======================  =====================================  ============
-   ``status``               The expected response status code.     defaults to
-                            Multiple acceptable response codes     ``200``
-                            may be provided, separated by ``||``
-                            (e.g. ``302 || 301`` - note, however,
-                            that this indicates ambiguity, which
-                            is generally undesirable).
+   ==============================  =====================================  ============
+   Key                             Description                            Notes
+   ==============================  =====================================  ============
+   ``status``                      The expected response status code.     defaults to
+                                   Multiple acceptable response codes     ``200``
+                                   may be provided, separated by ``||``
+                                   (e.g. ``302 || 301`` - note, however,
+                                   that this indicates ambiguity, which
+                                   is generally undesirable).
 
-   ``response_headers``     A dictionary of key-value pairs
-                            representing expected response header
-                            names and values. If a header's value
-                            is wrapped in ``/.../``, it will be
-                            treated as a regular expression.
+   ``response_headers``            A dictionary of key-value pairs
+                                   representing expected response header
+                                   names and values. If a header's value
+                                   is wrapped in ``/.../``, it will be
+                                   treated as a regular expression.
 
-   ``response_strings``     A list of string fragments expected
-                            to be present in the response body.
+   ``response_forbidden_headers``  A list of headers which must `not`
+                                   be present.
 
-   ``response_json_paths``  A dictionary of JSONPath rules paired
-                            with expected matches. Using this
-                            rule requires that the content being
-                            sent from the server is JSON (i.e. a
-                            content type of ``application/json``
-                            or containing ``+json``)
+   ``response_strings``            A list of string fragments expected
+                                   to be present in the response body.
 
-   ``poll``                 A dictionary of two keys:
+   ``response_json_paths``         A dictionary of JSONPath rules paired
+                                   with expected matches. Using this
+                                   rule requires that the content being
+                                   sent from the server is JSON (i.e. a
+                                   content type of ``application/json``
+                                   or containing ``+json``)
 
-                            * ``count``: An integer stating the
-                              number of times to attempt this
-                              test before giving up.
-                            * ``delay``: A floating point number
-                              of seconds to delay between
-                              attemmpts.
+   ``poll``                        A dictionary of two keys:
 
-                            This makes it possible to poll for a
-                            resource created via an asynchronous
-                            request. Use with caution.
-   =======================  =====================================  ============
+                                   * ``count``: An integer stating the
+                                     number of times to attempt this
+                                     test before giving up.
+                                   * ``delay``: A floating point number
+                                     of seconds to delay between
+                                     attemmpts.
+
+                                   This makes it possible to poll for a
+                                   resource created via an asynchronous
+                                   request. Use with caution.
+   ==============================  =====================================  ============
 
 Note that many of these items allow substitutions (explained below).
 
@@ -225,6 +228,7 @@ All of these variables may be used in all of the following fields:
 * ``response_strings``
 * ``response_json_paths`` (on the value side of the key value pair)
 * ``response_headers`` (on the value side of the key value pair)
+* ``response_forbidden_headers``
 
 With these variables it ought to be possible to traverse an API without any
 explicit statements about the URLs being used. If you need a

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -40,6 +40,7 @@ from gabbi import suite as gabbi_suite
 
 
 RESPONSE_HANDLERS = [
+    handlers.ForbiddenHeadersResponseHandler,
     handlers.HeadersResponseHandler,
     handlers.StringResponseHandler,
     handlers.JSONResponseHandler,

--- a/gabbi/handlers.py
+++ b/gabbi/handlers.py
@@ -110,6 +110,19 @@ class JSONResponseHandler(ResponseHandler):
                          % (path, expected, match))
 
 
+class ForbiddenHeadersResponseHandler(ResponseHandler):
+    """Test that listed headers are not in the response."""
+
+    test_key_suffix = 'forbidden_headers'
+    test_key_value = []
+
+    def action(self, test, forbidden, value=None):
+        # normalize forbidden header to lower case
+        forbidden = test.replace_template(forbidden).lower()
+        test.assertNotIn(forbidden, test.response,
+                         'Forbidden header %s found in response' % forbidden)
+
+
 class HeadersResponseHandler(ResponseHandler):
     """Compare expected headers with actual headers.
 

--- a/gabbi/tests/gabbits_intercept/forbiddenheaders.yaml
+++ b/gabbi/tests/gabbits_intercept/forbiddenheaders.yaml
@@ -1,0 +1,30 @@
+#
+# Test that headers that should not be there are definitely not
+# there. These mostly test in a negative fashion.
+#
+
+tests:
+
+    - name: header not there basic
+      GET: /foobar
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foobar
+      response_forbidden_headers:
+          - no-there-one
+          - no-there-two
+
+    - name: header is there fail
+      xfail: True
+      GET: /foobar
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foobar
+      response_forbidden_headers:
+          - x-gabbi-url
+
+    - name: header is there fail case insensitive
+      xfail: True
+      GET: /foobar
+      response_headers:
+          x-gabbi-url: $SCHEME://$NETLOC/foobar
+      response_forbidden_headers:
+          - x-gaBBi-uRl

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -2,8 +2,8 @@
 # Run the tests and confirm that the stuff we expect to skip or fail
 # does.
 
-GREP_FAIL_MATCH='expected failures=9'
-GREP_SKIP_MATCH='skipped=2'
+GREP_FAIL_MATCH='expected failures=11,'
+GREP_SKIP_MATCH='skipped=2,'
 GREP_UXSUC_MATCH='unexpected successes=1'
 
 python setup.py testr && \


### PR DESCRIPTION
After much discussion this was determined to be the easiest and
cleanest way to accomplish a test which asserts "this header must
not be present". The ResponseHandler framework is used to good
effect to make short code.

The value of the response_forbidden_headers is a list of headers.
Case will be normalized to lower, which matches the internal
representation of the response headers dictionary.

Fixes #108