### PR TITLE
Expand support for testing with python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: python
+python:
+      - "3.5"
 install:
       - pip install tox 
 script:
@@ -9,12 +11,13 @@ env:
       - TOXENV=py32
       - TOXENV=py33
       - TOXENV=py34
+      - TOXENV=py35
       - TOXENV=pypy
       - TOXENV=pypy3
       - TOXENV=pep8
-      - TOXENV=py34-failskip
-      - TOXENV=py34-limit
-      - TOXENV=py34-prefix
+      - TOXENV=py35-failskip
+      - TOXENV=py35-limit
+      - TOXENV=py35-prefix
 
 notifications:
       irc: "chat.freenode.net#gabbi"

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Gabbi is a tool for running HTTP tests where requests and responses
 are represented in a declarative YAML-based form. See the docs_ for
 more details on features and formats.
 
-Gabbi is tested with Python 2.7, 3.4 and pypy and pypy3.
+Gabbi is tested with Python 2.7, 3.4, 3.5 and pypy and pypy3.
 
 Tests can be run using `unittest`_ style test runners or from the
 command line with a `gabbi-run`_ script.

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifier =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
     Topic :: Internet :: WWW/HTTP :: WSGI
     Topic :: Software Development :: Testing
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py33,py34,py35,pypy,pypy3,pep8,limit,failskip,docs,py34-prefix,py34-limit,py34-failskip
+envlist = py27,py33,py34,py35,pypy,pypy3,pep8,limit,failskip,docs,py35-prefix,py35-limit,py35-failskip
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -15,7 +15,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = {posargs}
 
-[testenv:py34-prefix]
+[testenv:py35-prefix]
 setenv = GABBI_PREFIX=/snoopy
 
 [testenv:pep8]
@@ -29,10 +29,10 @@ commands = {toxinidir}/test-limit.sh
 [testenv:failskip]
 commands = {toxinidir}/test-failskip.sh
 
-[testenv:py34-limit]
+[testenv:py35-limit]
 commands = {toxinidir}/test-limit.sh
 
-[testenv:py34-failskip]
+[testenv:py35-failskip]
 commands = {toxinidir}/test-failskip.sh
 
 [testenv:cover]


### PR DESCRIPTION
As that's the state of the art.

For travis we install python 3.5 as the base python and then test
from there. This gets around some limitations in travis.