### PR TITLE
Remove tox from test-requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 mock
-tox
 testrepository
 coverage
 hacking


### PR DESCRIPTION
tox must be pre-installed in order to run tests, as `tox -epep8` or simply `tox` .  
Adding tox to test requirements is redundant as these packages are only required if used in `gabbi/tests` folder.