### PR TITLE
Jsonpath more

### DIFF
--- a/docs/source/jsonpath.rst
+++ b/docs/source/jsonpath.rst
@@ -7,10 +7,14 @@ validating response bodies that are formatted as JSON and making
 reference to that JSON in subsequent queries. `jsonpath_rw`_ is used
 to process the JSONPath expressions.
 
-To address a common requirement when evaluting JSON responses, an
-extension has been made to the default implementation of JSONPath.
-This extension is ``len`` and will return the length of the current
-datum in the JSONPath expression.
+To address common requirements when evaluting JSON responses,
+extensions have been made to the default implementation of JSONPath
+using `jsonpath_rw_ext`. It adds three useful functions:
+
+#. Return the length of the current datum using ``len``.
+#. Sort the current datum using ``sorted`` and ``[/name]``.
+#. Filter using ``[?name = "cow"]`` to select an item in the
+   current datum.
 
 Here is a simple JSONPath example, including use of ``len``. Given JSON data
 as follows::
@@ -36,6 +40,8 @@ follows::
         # The string at beta has five chars
         $.beta.`len`: 5
 
-There are more JSONPath examples in :doc:`example`.
+There are more JSONPath examples in :doc:`example` and in the
+`jsonpath_rw`_ and `jsonpath_rw_ext`_ documentation.
 
 .. _jsonpath_rw: http://jsonpath-rw.readthedocs.org/en/latest/
+.. _jsonpath_rw_ext: https://python-jsonpath-rw-ext.readthedocs.org/en/latest/

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -194,13 +194,16 @@ class HTTPTestCase(unittest.TestCase):
     def extract_json_path_value(data, path):
         """Extract the value at JSON Path path from the data.
 
-        The input data is a Python datastructre, not a JSON string.
+        The input data is a Python datastructure, not a JSON string.
         """
         path_expr = json_parser.parse(path)
         matches = [match.value for match in path_expr.find(data)]
-        try:
-            return matches[0]
-        except IndexError:
+        if matches:
+            if len(matches) > 1:
+                return matches
+            else:
+                return matches[0]
+        else:
             raise ValueError(
                 "JSONPath '%s' failed to match on data: '%s'" % (path, data))
 

--- a/gabbi/json_parser.py
+++ b/gabbi/json_parser.py
@@ -15,10 +15,12 @@
 import functools
 
 import jsonpath_rw
-from jsonpath_rw_ext import parser, _iterable
+from jsonpath_rw_ext import _iterable
+from jsonpath_rw_ext import parser
 
 
 PARSER = None
+
 
 def custom_find(self, datum):
     """Return sorted value of This if list or dict."""

--- a/gabbi/tests/gabbits_intercept/json_extensions.yaml
+++ b/gabbi/tests/gabbits_intercept/json_extensions.yaml
@@ -25,3 +25,36 @@ tests:
           $.beta: hello
           # the string at beta has five chars
           $.beta.`len`: 5
+
+    - name: test sort
+      url: /barfoo
+      method: POST
+      request_headers:
+          content-type: application/json
+      data:
+          objects:
+              - name: cow
+                value: moo
+              - name: cat
+                value: meow
+      response_json_paths:
+          $.objects[/name][0].value: meow
+          $.objects[/name][1].value: moo
+          $.objects[\name][1].value: meow
+          $.objects[\name][0].value: moo
+
+    - name: test filtered
+      url: /barfoo
+      method: POST
+      request_headers:
+          content-type: application/json
+      data:
+          objects:
+              - name: cow
+                value: moo
+              - name: cat
+                value: meow
+      response_json_paths:
+         $.objects[?name = "cow"].value: moo
+         $.objects[?name = "cat"].value: meow
+         $.objects[?value = "meow"].name: cat

--- a/gabbi/tests/test_jsonpath.py
+++ b/gabbi/tests/test_jsonpath.py
@@ -1,0 +1,73 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Test jsonpath handling
+"""
+
+import unittest
+
+from gabbi import case
+
+
+extract = case.HTTPTestCase.extract_json_path_value
+nested_data = {
+    'objects': [
+        {'name': 'one', 'value': 'alpha'},
+        {'name': 'two', 'value': 'beta'},
+    ]
+}
+simple_list = {
+    'objects': [
+        'alpha',
+        'gamma',
+        'gabba',
+        'hey',
+        'carlton',
+    ]
+}
+
+
+class JSONPathTest(unittest.TestCase):
+
+    def test_basic_match(self):
+        data = ['hi']
+        match = extract(data, '$[0]')
+        self.assertEqual('hi', match)
+
+    def test_list_handling(self):
+        data = ['hi', 'bye']
+        match = extract(data, '$')
+        self.assertEqual(data, match)
+
+    def test_embedded_list_handling(self):
+        match = extract(nested_data, '$.objects..name')
+        self.assertEqual(['one', 'two'], match)
+
+    def test_sorted_object_list(self):
+        match = extract(nested_data, r'$.objects[\name][0].value')
+        self.assertEqual('beta', match)
+
+    def test_filtered_list(self):
+        match = extract(nested_data, r'$.objects[?name = "one"].value')
+        self.assertEqual('alpha', match)
+
+    def test_sorted_simple_list(self):
+        match = extract(simple_list, r'$.objects.`sorted`[-1]')
+        self.assertEqual('hey', match)
+
+    def test_len_simple_list(self):
+        match = extract(simple_list, r'$.objects.`len`')
+        self.assertEqual(5, match)
+
+    def test_len_object_list(self):
+        match = extract(nested_data, '$.objects.`len`')
+        self.assertEqual(2, match)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pbr
 six
 PyYAML
 httplib2
-jsonpath-rw
+jsonpath-rw-ext
 wsgi-intercept>=1.0.0
 colorama


### PR DESCRIPTION
This adds support for sorting and filtering in json paths, using jsonpath_rw_ext with a slight modification to allow the results to be traversable (see [pull request](https://github.com/sileht/python-jsonpath-rw-ext/pull/7)).

Fixes #114
Fixes #86 

/cc @FND @jasonamyers 