### PR TITLE
Adjust header evaluation to always use strings

### DIFF
--- a/gabbi/handlers.py
+++ b/gabbi/handlers.py
@@ -128,6 +128,8 @@ class HeadersResponseHandler(ResponseHandler):
 
     If a header value is wrapped in ``/`` it is treated as a raw
     regular expression.
+
+    Headers values are always treated as strings.
     """
 
     test_key_suffix = 'headers'
@@ -137,10 +139,10 @@ class HeadersResponseHandler(ResponseHandler):
         header = header.lower()  # case-insensitive comparison
 
         response = test.response
-        header_value = test.replace_template(value)
+        header_value = test.replace_template(str(value))
 
         try:
-            response_value = response[header]
+            response_value = str(response[header])
         except KeyError:
             raise AssertionError(
                 "'%s' header not present in response: %s" % (
@@ -153,6 +155,6 @@ class HeadersResponseHandler(ResponseHandler):
                 'Expect header %s to match /%s/, got %s' %
                 (header, header_value, response_value))
         else:
-            test.assertEqual(header_value, response[header],
+            test.assertEqual(header_value, response_value,
                              'Expect header %s with value %s, got %s' %
                              (header, header_value, response[header]))

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -173,6 +173,17 @@ class HandlersTest(unittest.TestCase):
         self.assertIn("'location' header not present in response:",
                       str(failure.exception))
 
+    def test_resonse_headers_stringify(self):
+        handler = handlers.HeadersResponseHandler(self.test_class)
+        self.test.test_data = {'response_headers': {
+            'x-alpha-beta': 2.0,
+        }}
+        self.test.response = {'x-alpha-beta': '2.0'}
+        self._assert_handler(handler)
+
+        self.test.response = {'x-alpha-beta': 2.0}
+        self._assert_handler(handler)
+
     def _assert_handler(self, handler):
         # Instantiate our contained test class by naming its test
         # method and then run its tests to confirm.


### PR DESCRIPTION
Sometimes yaml will provide a header response value as a numeral.
We don't want that. So to be explicit both sides of the header value
test are stringified: both the value in the real reaponse, and the
value of the expected response.

Fixes #112 

/cc @FND, @jasonamyers 