### PR TITLE
Support testing of full json responses

### DIFF
--- a/docs/source/jsonpath.rst
+++ b/docs/source/jsonpath.rst
@@ -48,6 +48,22 @@ If the ordering is *not* predictable additional effort is required::
         # filter by type = dog
         $.pets[?type = "dog"].sound: woof
 
+If it is necessary to validate the entire JSON response use a
+JSONPath of ``$``::
+
+    response_json_paths:
+        $:
+            pets:
+                - type: cat
+                  sound: meow
+                - type: dog
+                  sound: woof
+
+This is not a technique that should be used frequently as it can
+lead to difficult to read tests and it also indicates that your
+gabbi tests are being used to test your serializers and data models,
+not just your API interactions.
+
 There are more JSONPath examples in :doc:`example` and in the
 `jsonpath_rw`_ and `jsonpath_rw_ext`_ documentation.
 

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -335,7 +335,7 @@ class HTTPTestCase(unittest.TestCase):
         for name in headers:
             headers[name] = self.replace_template(headers[name])
 
-        if test['data']:
+        if test['data'] is not '':
             body = self._test_data_to_string(
                 test['data'], headers.get('content-type', ''))
         else:

--- a/gabbi/tests/gabbits_intercept/jsonbody.yaml
+++ b/gabbi/tests/gabbits_intercept/jsonbody.yaml
@@ -1,0 +1,38 @@
+# See if $ is the whole thing
+
+tests:
+
+    - name: test fully body
+      url: /foobar
+      method: POST
+      request_headers:
+          content-type: application/json
+      data:
+          alpha:
+              - one
+              - two
+          beta: hello
+      response_json_paths:
+          $:
+            alpha:
+               - one
+               - two
+            beta: hello
+
+    - name: test empty dict
+      url: /foobar
+      method: POST
+      request_headers:
+          content-type: application/json
+      data: {}
+      response_json_paths:
+          $: {}
+
+    - name: test empty list
+      url: /foobar
+      method: POST
+      request_headers:
+          content-type: application/json
+      data: []
+      response_json_paths:
+          $: []


### PR DESCRIPTION
This feature was effectively already there but not fleshed out in
tests nor documentation. Now there are some tests and a short
piece of documentation with a light warning about avoiding overuse.

A slight adjustment was required in data handling to deal with
empty lists and empty objects.

Fixes #113

/cc @FND @jasonamyers 