### PR TITLE
Switch to use urllib3 from httplib2

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -284,7 +284,7 @@ class HTTPTestCase(unittest.TestCase):
         return re.sub(self._replacer_regex('RESPONSE'),
                       self._json_replacer, message)
 
-    def _run_request(self, url, method, headers, body):
+    def _run_request(self, url, method, headers, body, redirect=False):
         """Run the http request and decode output.
 
         The call to make the request will catch a WSGIAppError from
@@ -300,7 +300,8 @@ class HTTPTestCase(unittest.TestCase):
                 url,
                 method=method,
                 headers=headers,
-                body=body
+                body=body,
+                redirect=redirect
             )
         except wsgi_intercept.WSGIAppError as exc:
             # Extract and re-raise the wrapped exception.
@@ -341,18 +342,14 @@ class HTTPTestCase(unittest.TestCase):
         else:
             body = ''
 
-        # Reset follow_redirects with every go.
-        self.http.follow_redirects = False
-        if test['redirects']:
-            self.http.follow_redirects = True
-
         if test['poll']:
             count = test['poll'].get('count', 1)
             delay = test['poll'].get('delay', 1)
             failure = None
             while count:
                 try:
-                    self._run_request(full_url, method, headers, body)
+                    self._run_request(full_url, method, headers, body,
+                                      redirect=test['redirects'])
                     self._assert_response()
                     failure = None
                     break
@@ -365,7 +362,8 @@ class HTTPTestCase(unittest.TestCase):
             if failure:
                 raise failure
         else:
-            self._run_request(full_url, method, headers, body)
+            self._run_request(full_url, method, headers, body,
+                              redirect=test['redirects'])
             self._assert_response()
 
     def _scheme_replace(self, message):

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -14,7 +14,7 @@
 
 The test case encapsulates the request headers and body and expected
 response headers and body. When the test is run an HTTP request is
-made using httplib2. Assertions are made against the reponse.
+made using urllib3. Assertions are made against the reponse.
 """
 
 from collections import OrderedDict
@@ -293,7 +293,7 @@ class HTTPTestCase(unittest.TestCase):
         """
 
         if 'user-agent' not in (key.lower() for key in headers):
-            headers['user-agent'] = "gabbi/%s (Python httplib2)" % __version__
+            headers['user-agent'] = "gabbi/%s (Python urllib3)" % __version__
 
         try:
             response, content = self.http.request(

--- a/gabbi/httpclient.py
+++ b/gabbi/httpclient.py
@@ -17,12 +17,32 @@ from __future__ import print_function
 import os
 import sys
 
-import httplib2
+import urllib3
 
 from gabbi import utils
 
 
-class VerboseHttp(httplib2.Http):
+class Http(urllib3.PoolManager):
+
+    def request(self, absolute_uri, method, body, headers, redirect):
+
+        retries = 1 if redirect else False
+        response = super(Http, self).request(
+            method, absolute_uri, body=body, headers=headers,
+            redirect=redirect, retries=retries)
+
+        # Transform response into something akin to httplib2
+        # response object.
+        content = response.data
+        status = response.status
+        reason = response.reason
+        headers = response.headers
+        headers['status'] = str(status)
+        headers['reason'] = reason
+        return headers, content
+
+
+class VerboseHttp(Http):
     """A subclass of Http that verbosely reports on activity.
 
     If the output is a tty or ``GABBI_FORCE_COLOR`` is set in the
@@ -68,28 +88,25 @@ class VerboseHttp(httplib2.Http):
             self.colorize = utils.get_colorizer(self._stream)
         super(VerboseHttp, self).__init__(**kwargs)
 
-    def _request(self, conn, host, absolute_uri, request_uri, method, body,
-                 headers, redirections, cachekey):
+    def request(self, absolute_uri, method, body, headers, redirect):
         """Display request parameters before requesting."""
 
         self._verbose_output('#### %s ####' % self.caption,
                              color=self.COLORMAP['caption'])
-        self._verbose_output('%s %s' % (method, request_uri),
+        self._verbose_output('%s %s' % (method, absolute_uri),
                              prefix=self.REQUEST_PREFIX,
                              color=self.COLORMAP['request'])
-        self._print_header("Host", host, prefix=self.REQUEST_PREFIX)
 
         self._print_headers(headers, prefix=self.REQUEST_PREFIX)
         self._print_body(headers, body)
 
-        (response, content) = httplib2.Http._request(
-            self, conn, host, absolute_uri, request_uri, method, body,
-            headers, redirections, cachekey
-        )
+        response, content = super(VerboseHttp, self).request(
+            absolute_uri, method, body, headers, redirect)
 
         # Blank line for division
         self._verbose_output('')
-        self._verbose_output('%s %s' % (response['status'], response.reason),
+        self._verbose_output('%s %s' % (response['status'],
+                                        response['reason']),
                              prefix=self.RESPONSE_PREFIX,
                              color=self.COLORMAP['status'])
         self._print_headers(response, prefix=self.RESPONSE_PREFIX)
@@ -144,4 +161,4 @@ def get_http(verbose=False, caption=''):
             body = False
         return VerboseHttp(body=body, headers=headers, colorize=colorize,
                            stream=stream, caption=caption)
-    return httplib2.Http()
+    return Http()

--- a/gabbi/httpclient.py
+++ b/gabbi/httpclient.py
@@ -25,11 +25,12 @@ from gabbi import utils
 class Http(urllib3.PoolManager):
 
     def request(self, absolute_uri, method, body, headers, redirect):
-
-        retries = 1 if redirect else False
+        if redirect:
+            retry = urllib3.util.Retry(raise_on_redirect=False, redirect=5)
+        else:
+            retry = urllib3.util.Retry(total=False, redirect=False)
         response = super(Http, self).request(
-            method, absolute_uri, body=body, headers=headers,
-            redirect=redirect, retries=retries)
+            method, absolute_uri, body=body, headers=headers, retries=retry)
 
         # Transform response into something akin to httplib2
         # response object.

--- a/gabbi/httpclient.py
+++ b/gabbi/httpclient.py
@@ -64,7 +64,7 @@ class VerboseHttp(Http):
     """
 
     # A list of request and response headers to never display.
-    # Can include httplib2 response object attributes that are not
+    # Can include response object attributes that are not
     # technically headers.
     HEADER_BLACKLIST = [
         'status',

--- a/gabbi/suite.py
+++ b/gabbi/suite.py
@@ -65,7 +65,7 @@ class GabbiSuite(suite.TestSuite):
         try:
             with fixture.nest([fix() for fix in fixtures]):
                 if intercept:
-                    with interceptor.Httplib2Interceptor(
+                    with interceptor.Urllib3Interceptor(
                             intercept, host, port, prefix):
                         result = super(GabbiSuite, self).run(result, debug)
                 else:

--- a/gabbi/tests/test_runner.py
+++ b/gabbi/tests/test_runner.py
@@ -18,7 +18,7 @@ import unittest
 from uuid import uuid4
 
 from six import StringIO
-from wsgi_intercept.interceptor import Httplib2Interceptor
+from wsgi_intercept.interceptor import Urllib3Interceptor
 
 from gabbi import driver
 from gabbi import handlers
@@ -36,7 +36,7 @@ class RunnerTest(unittest.TestCase):
         host, port = (str(uuid4()), 8000)
         self.host = host
         self.port = port
-        self.server = lambda: Httplib2Interceptor(SimpleWsgi, host, port, '')
+        self.server = lambda: Urllib3Interceptor(SimpleWsgi, host, port, '')
 
         self._stdin = sys.stdin
 
@@ -73,7 +73,7 @@ class RunnerTest(unittest.TestCase):
                 self.assertSuccess(err)
 
     def test_target_url_parsing_standard_port(self):
-        self.server = lambda: Httplib2Interceptor(
+        self.server = lambda: Urllib3Interceptor(
             SimpleWsgi, self.host, 80, '')
         sys.argv = ['gabbi-run', 'http://%s/foo' % self.host]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pbr
 six
 PyYAML
-httplib2
+urllib3
 jsonpath-rw-ext>=1.0.0
-wsgi-intercept>=1.0.0
+wsgi-intercept>=1.2.0
 colorama


### PR DESCRIPTION
httplib2's maintenance status is in doubt so using urllib3 is a bit
more sane because it is the active and preferred choice for http
library that provides a high level of control and low level of magic.

This changes both the client for making the requests, and the
wsgi-intercept handling.

The details of the changes are in gabbi.httpclient which creates
a lightweight facade over the urllib3.PoolManager.request method
to transform the results into something that has the shape of an
httplib2 response, content pair.