### PR TITLE
Pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
       - TOXENV=py35-failskip
       - TOXENV=py35-limit
       - TOXENV=py35-prefix
+      - TOXENV=py27-pytest
+      - TOXENV=py35-pytest
 
 notifications:
       irc: "chat.freenode.net#gabbi"

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,9 @@ more details on features and formats.
 
 Gabbi is tested with Python 2.7, 3.4, 3.5 and pypy.
 
-Tests can be run using `unittest`_ style test runners or from the
-command line with a `gabbi-run`_ script.
+Tests can be run using `unittest`_ style test runners, `pytest`_ (with
+one limitation described in the docs) or from the command line with
+a `gabbi-run`_ script.
 
 There is a `gabbi-demo`_ repository which provides a tutorial via
 its commit history. The demo builds a simple API using gabbi to
@@ -23,6 +24,7 @@ facilitate test driven development.
 .. _docs: https://gabbi.readthedocs.org/
 .. _gabbi-demo: https://github.com/cdent/gabbi-demo
 .. _unittest: https://gabbi.readthedocs.org/en/latest/example.html#loader
+.. _pytest: http://pytest.org/
 .. _gabbi-run: https://gabbi.readthedocs.org/en/latest/runner.html
 
 Purpose

--- a/docs/source/example.rst
+++ b/docs/source/example.rst
@@ -14,20 +14,23 @@ harness.
 Loader
 ------
 
-Test Loader
-~~~~~~~~~~~
+To run the tests they must be generated in some fashion and then
+run. This is accomplished by a test loader. Initially gabbi only
+supported those test harnesses that supported the ``load_tests``
+protocol in UnitTest. It now possible to also build and run tests
+with pytest_ with some limitations described below.
 
-To run those tests a test loader is required. That would look a
-bit like this:
+UnitTest Style Loader
+~~~~~~~~~~~~~~~~~~~~~
+
+To run the tests with a ``load_tests`` style loader a test file containing
+a ``load_tests`` method is required. That will look a bit like:
 
 .. literalinclude:: example.py
    :language: python
 
 For details on the arguments available when building tests see
 :meth:`~gabbi.driver.build_tests`.
-
-Run Test Loader
-~~~~~~~~~~~~~~~
 
 Once the test loader has been created, it needs to be run. There are *many*
 options. Which is appropriate depends very much on your environment. Here are
@@ -54,5 +57,27 @@ See the `source distribution`_ and `the tutorial repo`_ for more
 advanced options, including using ``testrepository`` and
 ``subunit``.
 
+pytest
+~~~~~~
+
+Since pytest does not support the ``load_tests`` system, a different
+way of generating tests is required. A test file must be created
+that calls :meth:`~gabbi.driver.py_test_generator` and yields the
+generated tests. That will look a bit like this:
+
+.. literalinclude:: pytest-example.py
+   :language: python
+
+This can then be run with the usual pytest commands. For example::
+
+   py.test -svx pytest-example.py
+
+.. warning:: When using the unittest runners, it is possible to select
+             just one test from a YAML file and cause it and all its
+             prior tests to run. This **does not** work when using
+             pytest. It will traverse the prior tests and then exit
+             after the first one has run. Fixing this is desirable.
+
 .. _source distribution: https://github.com/cdent/gabbi
 .. _the tutorial repo: https://github.com/cdent/gabbi-demo
+.. _pytest: http://pytest.org/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,7 +30,7 @@ Initiative" or "Glorious And Basic Beta Investigator". These
 are not good enough so the search continues.
 
 Tests can be run using :ref:`unittest <test_loaders>` style test
-runners or from the command line with a :doc:`gabbi-run <runner>` script.
+runners or py.test or from the command line with a :doc:`gabbi-run <runner>` script.
 
 If you want to get straight to creating tests look at
 :doc:`example`, the test files in the `source distribution`_

--- a/docs/source/pytest-example.py
+++ b/docs/source/pytest-example.py
@@ -1,0 +1,28 @@
+"""A sample pytest module."""
+
+# For pathname munging
+import os
+
+# The module that build_tests comes from.
+from gabbi import driver
+
+# We need access to the WSGI application that hosts our service
+from myapp import wsgiapp
+
+# We're using fixtures in the YAML files, we need to know where to
+# load them from.
+from myapp.test import fixtures
+
+# By convention the YAML files are put in a directory named
+# "gabbits" that is in the same directory as the Python test file.
+TESTS_DIR = 'gabbits'
+
+
+def test_gabbits():
+    test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
+    test_generator = driver.py_test_generator(
+        test_dir, intercept=wsgiapp.app,
+        fixture_module=fixtures)
+
+    for test in test_generator:
+        yield test

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -28,6 +28,7 @@ import glob
 import inspect
 import io
 import os
+import unittest
 from unittest import suite
 import uuid
 
@@ -231,6 +232,30 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
                                           intercept, prefix)
         top_suite.addTest(file_suite)
     return top_suite
+
+
+def py_test_generator(test_dir, host=None, port=8001, intercept=None,
+                      prefix=None, test_loader_name=None,
+                      fixture_module=None, response_handlers=None):
+    """Generate tests cases for py.test
+
+    This uses build_tests to create TestCases and then yields them in
+    a way that pytest can handle.
+    """
+    loader = unittest.TestLoader()
+    tests = build_tests(test_dir, loader, host=host, port=port,
+                        intercept=intercept,
+                        test_loader_name=test_loader_name,
+                        fixture_module=fixture_module,
+                        response_handlers=response_handlers,
+                        prefix=prefix)
+
+    for test in tests:
+        if hasattr(test, '_tests'):
+            for subtest in test._tests:
+                yield '%s' % subtest.__class__.__name__, subtest
+        else:
+            yield '%s' % test.__class__.__name__, test
 
 
 def load_yaml(yaml_file):

--- a/gabbi/tests/test_gabbits_pytest.py
+++ b/gabbi/tests/test_gabbits_pytest.py
@@ -1,0 +1,40 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Test pytest driving of tests.
+
+Unittest loaders don't see this file and pytest doesn't see load_tests,
+so we manage to get coverage across both types of drivers, from tox,
+without duplication.
+"""
+
+import os
+
+from gabbi import driver
+from gabbi.tests import simple_wsgi
+from gabbi.tests import test_intercept
+
+TESTS_DIR = 'gabbits_intercept'
+
+
+def test_from_build():
+
+    test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
+    test_generator = driver.py_test_generator(
+        test_dir, intercept=simple_wsgi.SimpleWsgi,
+        fixture_module=test_intercept,
+        response_handlers=[test_intercept.TestResponseHandler])
+
+    # TODO(cdent): Where is our Python3!
+    # yield from test_generator
+    for test in test_generator:
+        yield test

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 mock
+pytest
 testrepository
 coverage
 hacking

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py33,py34,py35,pypy,pep8,limit,failskip,docs,py35-prefix,py35-limit,py35-failskip
+envlist = py27,py33,py34,py35,pypy,pep8,limit,failskip,docs,py35-prefix,py35-limit,py35-failskip,py27-pytest,py35-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -14,6 +14,12 @@ commands = python setup.py testr --testr-args="{posargs}"
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = {posargs}
+
+[testenv:py27-pytest]
+commands = py.test gabbi
+
+[testenv:py35-pytest]
+commands = py.test gabbi
 
 [testenv:py35-prefix]
 setenv = GABBI_PREFIX=/snoopy


### PR DESCRIPTION
This branch provides rudimentary support for running gabbi managed tests with py.test as well as the tests-of-gabbi with py.test in additional tox targets. There is a shortcoming (noted in the docs) but I don't think it is enough of a problem to not make this available for the hardy and willing.

/cc @FND @jasonamyers 