### PR TITLE
Fix pytest failure handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,8 @@ more details on features and formats.
 
 Gabbi is tested with Python 2.7, 3.4, 3.5 and pypy.
 
-Tests can be run using `unittest`_ style test runners, `pytest`_ (with
-one limitation described in the docs) or from the command line with
-a `gabbi-run`_ script.
+Tests can be run using `unittest`_ style test runners, `pytest`_ 
+or from the command line with a `gabbi-run`_ script.
 
 There is a `gabbi-demo`_ repository which provides a tutorial via
 its commit history. The demo builds a simple API using gabbi to

--- a/docs/source/example.rst
+++ b/docs/source/example.rst
@@ -72,12 +72,6 @@ This can then be run with the usual pytest commands. For example::
 
    py.test -svx pytest-example.py
 
-.. warning:: When using the unittest runners, it is possible to select
-             just one test from a YAML file and cause it and all its
-             prior tests to run. This **does not** work when using
-             pytest. It will traverse the prior tests and then exit
-             after the first one has run. Fixing this is desirable.
-
 .. _source distribution: https://github.com/cdent/gabbi
 .. _the tutorial repo: https://github.com/cdent/gabbi-demo
 .. _pytest: http://pytest.org/

--- a/gabbi/reporter.py
+++ b/gabbi/reporter.py
@@ -13,8 +13,11 @@
 # under the License.
 """TestRunner and TestResult for gabbi-run."""
 
+from unittest import TestResult
 from unittest import TextTestResult
 from unittest import TextTestRunner
+
+import pytest
 
 from gabbi import utils
 
@@ -98,6 +101,21 @@ class ConciseTestResult(TextTestResult):
             message = str(err[1])
             for line in message.splitlines():
                 self.stream.writeln('\t%s' % line)
+
+
+class PyTestResult(TestResult):
+
+    def addFailure(self, test, err):
+        raise err[1]
+
+    def addError(self, test, err):
+        raise err[1]
+
+    def addSkip(self, test, reason):
+        pytest.skip(reason)
+
+    def addExpectedFailure(self, test, err):
+        pytest.xfail('%s' % err[1])
 
 
 class ConciseTestRunner(TextTestRunner):

--- a/gabbi/tests/test_gabbits_pytest.py
+++ b/gabbi/tests/test_gabbits_pytest.py
@@ -28,6 +28,7 @@ TESTS_DIR = 'gabbits_intercept'
 
 def test_from_build():
 
+    os.environ['GABBI_TEST_URL'] = 'takingnames'
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
     test_generator = driver.py_test_generator(
         test_dir, intercept=simple_wsgi.SimpleWsgi,

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -5,9 +5,13 @@
 GREP_FAIL_MATCH='expected failures=11,'
 GREP_SKIP_MATCH='skipped=2,'
 GREP_UXSUC_MATCH='unexpected successes=1'
+PYTEST_MATCH='2 skipped, 11 xfailed'
 
 python setup.py testr && \
     for match in "${GREP_FAIL_MATCH}" "${GREP_UXSUC_MATCH}" "${GREP_SKIP_MATCH}"; do
         testr last --subunit | subunit2pyunit 2>&1 | \
             grep "${match}"
     done
+
+# Make sure pytest failskips too
+py.test gabbi | grep "$PYTEST_MATCH"


### PR DESCRIPTION
Fixes #124

Though pytest was collecting and running tests, the results were
not actually being handled. If a test failed, it still appeared to
pass. The fundamental reason for this is that only the GabbiSuite
which contains all the tests from each YAML file was being checked.
These look like tests to pytest and pass.

The eventual fix is fairly complex and could maybe be made less so
by learning how to use modern parameterized pytest[1] rather than the
old yield style being used here. The fix includes:

* Creating a PyTestResult class which translates various unitest
  result types into pytest skips or xfails or reraises errors as
  required.

* Works around the GabbiSuite.run() based fixture handling that
  unitest-based runners automatically use but won't work properly
  in the pytest yield setting by adding start() and stop() methods
  the suite and yielding artifical tests which call start and stop.[2]

Besides getting failing tests to actually fail this also gets some
other features working:

* xfail and skip work, including skipping an entire yaml file with
  he SkipFixture
* If a single test from a file is selected, all the prior tests in
  the file will run too, but only the one requested will report.

[1] http://pytest.org/latest/parametrize.html#pytest-generate-tests

[2] This causes the number of tests to increase but it seems to be the
only way to get things working without larger changes.