### PR TITLE
move pytest from test-req to req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pbr
 six
+pytest
 PyYAML
 urllib3>=1.11.0
 jsonpath-rw-ext>=1.0.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 mock
-pytest
 testrepository
 coverage
 hacking


### PR DESCRIPTION
we already import pytest in our production code, hence it should be
in requirements.txt rather than test-requirements.txt, otherwise
downstream may fail when usig gabbi

ref: http://logs.openstack.org/53/306753/2/check/gate-aodh-dsvm-functional-hbase/a8f48e6/console.html#_2016-04-16_15_53_52_203