### PR TITLE
Cookie substitution

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -211,6 +211,9 @@ processed in the order given.
   string value of the environment variable is ``"True"`` or
   ``"False"`` then the resulting value will be the corresponding
   boolean, not a string.
+* ``$COOKIE``: All the cookies set by any ``Set-Cookie`` headers in
+  the prior response, including only the cookie key and value pairs
+  and no metadata (e.g. ``expires`` or ``domain``).
 * ``$LAST_URL``: The URL defined in the prior request, after
   substitutions have been made.
 * ``$LOCATION``: The location header returned in the prior response.

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -30,6 +30,7 @@ from unittest import case
 
 import six
 from six.moves.urllib import parse as urlparse
+from six.moves import http_cookies
 import wsgi_intercept
 
 from gabbi import __version__
@@ -44,6 +45,7 @@ REPLACERS = [
     'NETLOC',
     'ENVIRON',
     'LOCATION',
+    'COOKIE',
     'LAST_URL',
     'HEADERS',
     'RESPONSE',
@@ -207,6 +209,17 @@ class HTTPTestCase(unittest.TestCase):
         else:
             raise ValueError(
                 "JSONPath '%s' failed to match on data: '%s'" % (path, data))
+
+    def _cookie_replace(self, message):
+        """Replace $COOKIE in a message.
+
+        With cookie data from set-cookie in the prior request.
+        """
+        response_cookies = self.prior.response['set-cookie']
+        cookies = http_cookies.SimpleCookie()
+        cookies.load(response_cookies)
+        cookie_string = cookies.output(attrs=[], header='', sep=',').strip()
+        return message.replace('$COOKIE', cookie_string)
 
     def _headers_replace(self, message):
         """Replace a header indicator in a message with that headers value from

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -29,8 +29,8 @@ import unittest
 from unittest import case
 
 import six
-from six.moves.urllib import parse as urlparse
 from six.moves import http_cookies
+from six.moves.urllib import parse as urlparse
 import wsgi_intercept
 
 from gabbi import __version__

--- a/gabbi/tests/gabbits_intercept/cookie.yaml
+++ b/gabbi/tests/gabbits_intercept/cookie.yaml
@@ -1,0 +1,12 @@
+
+tests:
+- name: get a cookie
+  GET: /cookie
+  response_headers:
+      set-cookie: session=1234; domain=.example.com
+
+- name: use that cookie in a URL
+  desc: just to get it somewhere we can test it and confirm domain is dropped
+  GET: /cookie?$COOKIE
+  response_headers:
+      x-gabbi-url: $SCHEME://$NETLOC/cookie?session=1234

--- a/gabbi/tests/gabbits_intercept/cookie.yaml
+++ b/gabbi/tests/gabbits_intercept/cookie.yaml
@@ -6,7 +6,14 @@ tests:
       set-cookie: session=1234; domain=.example.com
 
 - name: use that cookie in a URL
-  desc: just to get it somewhere we can test it and confirm domain is dropped
-  GET: /cookie?$COOKIE
+  desc: to get it somewhere we can test it and confirm domain is dropped
+  GET: /foobar?$COOKIE
   response_headers:
-      x-gabbi-url: $SCHEME://$NETLOC/cookie?session=1234
+      x-gabbi-url: $SCHEME://$NETLOC/foobar?session=1234
+
+- name: confirm no cookies causes error
+  desc: "this will cause data unavailable: set-cookie"
+  xfail: true
+  GET: /foobar?$COOKIE
+  response_headers:
+      x-gabbi-url: $SCHEME://$NETLOC/foobar

--- a/gabbi/tests/simple_wsgi.py
+++ b/gabbi/tests/simple_wsgi.py
@@ -105,6 +105,8 @@ class SimpleWsgi(object):
                 else:
                     CURRENT_POLL = 0
             # fall through if we've ended the loop
+        elif path_info == '/cookie':
+            headers.append(('Set-Cookie', 'session=1234; domain=.example.com'))
 
         start_response('200 OK', headers)
 

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -7,12 +7,12 @@ shopt -s nocasematch
 [[ "${GABBI_SKIP_NETWORK:-false}" == "true" ]] && SKIP=7 || SKIP=2
 shopt -u nocasematch
 
-GREP_FAIL_MATCH='expected failures=11,'
+GREP_FAIL_MATCH='expected failures=12,'
 GREP_SKIP_MATCH="skipped=$SKIP,"
 GREP_UXSUC_MATCH='unexpected successes=1'
 # This skip is always 2 because the pytest tests don't
 # run the live tests.
-PYTEST_MATCH='2 skipped, 11 xfailed'
+PYTEST_MATCH='2 skipped, 12 xfailed'
 
 python setup.py testr && \
     for match in "${GREP_FAIL_MATCH}" "${GREP_UXSUC_MATCH}" "${GREP_SKIP_MATCH}"; do


### PR DESCRIPTION
This branch provides a way of using a $COOKIE substitution to send the cookies set via a `set-cookie` in the prior response in this current request. Both @FND and I have gazed over it and been a bit "well yeah, it does what it is supposed to do but somehow seems meh" so it would be great to get some further input from @jasonamyers and @martynbristow on this, just for sanity checking.