### PR TITLE
Get gabbi working with IPv6 addresses

### DIFF
--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -32,5 +32,8 @@ or in the target URL::
 The value of prefix will be prepended to the path portion of URLs that
 are not fully qualified.
 
+Anywhere host is used, if it is a raw IPV6 address it should be
+wrapped in ``[`` and ``]``.
+
 If a ``-x`` or ``--failfast`` argument is provided then ``gabbi-run`` will
 exit after the first test failure.

--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -67,7 +67,9 @@ def run():
         'target',
         nargs='?', default='stub',
         help='A fully qualified URL (with optional path as prefix) '
-             'to the primary target or a host and port, : separated'
+             'to the primary target or a host and port, : separated. '
+             'If using an IPV6 address for the host in either form, '
+             'wrap it in \'[\' and \']\'.'
     )
     parser.add_argument(
         'prefix',
@@ -98,11 +100,14 @@ def run():
         target = args.target
         prefix = args.prefix
 
-    if ':' in target:
-        host, port = target.split(':')
+    if ':' in target and '[' not in target:
+        host, port = target.rsplit(':', 1)
+    elif ']:' in target:
+        host, port = target.rsplit(':', 1)
     else:
         host = target
         port = None
+    host = host.replace('[', '').replace(']', '')
 
     # Initialize response handlers.
     custom_response_handlers = []

--- a/gabbi/tests/test_parse_url.py
+++ b/gabbi/tests/test_parse_url.py
@@ -40,21 +40,21 @@ class UrlParseTest(unittest.TestCase):
         return http_case
 
     def test_parse_url(self):
-        host = uuid.uuid4()
+        host = uuid.uuid4().hex
         http_case = self.make_test_case(host)
         parsed_url = http_case._parse_url('/foobar')
 
         self.assertEqual('http://%s:8000/foobar' % host, parsed_url)
 
     def test_parse_prefix(self):
-        host = uuid.uuid4()
+        host = uuid.uuid4().hex
         http_case = self.make_test_case(host, prefix='/noise')
         parsed_url = http_case._parse_url('/foobar')
 
         self.assertEqual('http://%s:8000/noise/foobar' % host, parsed_url)
 
     def test_parse_full(self):
-        host = uuid.uuid4()
+        host = uuid.uuid4().hex
         http_case = self.make_test_case(host)
         parsed_url = http_case._parse_url('http://example.com/house')
 
@@ -102,6 +102,37 @@ class UrlParseTest(unittest.TestCase):
 
         self.assertEqual('https://%s:80/foobar' % host, parsed_url)
 
+    def test_ipv6_url(self):
+        host = '::1'
+        http_case = self.make_test_case(host, port='80', ssl=True)
+        parsed_url = http_case._parse_url('/foobar')
+
+        self.assertEqual('https://[%s]:80/foobar' % host, parsed_url)
+
+    def test_ipv6_full_url(self):
+        host = '::1'
+        http_case = self.make_test_case(host, port='80', ssl=True)
+        parsed_url = http_case._parse_url(
+            'http://[2001:4860:4860::8888]/foobar')
+
+        self.assertEqual('http://[2001:4860:4860::8888]/foobar', parsed_url)
+
+    def test_ipv6_no_double_colon_wacky_ssl(self):
+        host = 'FEDC:BA98:7654:3210:FEDC:BA98:7654:3210'
+        http_case = self.make_test_case(host, port='80', ssl=True)
+        parsed_url = http_case._parse_url('/foobar')
+
+        self.assertEqual(
+            'https://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/foobar',
+            parsed_url)
+
+        http_case = self.make_test_case(host, ssl=True)
+        parsed_url = http_case._parse_url('/foobar')
+
+        self.assertEqual(
+            'https://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8000/foobar',
+            parsed_url)
+
     def test_add_query_params(self):
         host = uuid.uuid4().hex
         # Use a sequence of tuples to ensure order.
@@ -121,7 +152,7 @@ class UrlParseTest(unittest.TestCase):
         self.assertEqual('http://%s:8000/foobar?alpha=beta&x=1&y=2'
                          % host, parsed_url)
 
-    def test_extend_query_params_full_ulr(self):
+    def test_extend_query_params_full_url(self):
         host = 'stub'
         query = OrderedDict([('x', 1), ('y', 2)])
         http_case = self.make_test_case(host, params=query)

--- a/gabbi/tests/test_utils.py
+++ b/gabbi/tests/test_utils.py
@@ -132,3 +132,29 @@ class CreateURLTest(unittest.TestCase):
         url = utils.create_url('/foo/bar?x=1&y=2', 'test.host.com', ssl=True,
                                port=80)
         self.assertEqual('https://test.host.com:80/foo/bar?x=1&y=2', url)
+
+    def test_create_url_ipv6_ssl(self):
+        url = utils.create_url('/foo/bar?x=1&y=2', '::1', ssl=True)
+        self.assertEqual('https://[::1]/foo/bar?x=1&y=2', url)
+
+    def test_create_url_ipv6_ssl_weird_port(self):
+        url = utils.create_url('/foo/bar?x=1&y=2', '::1', ssl=True, port=80)
+        self.assertEqual('https://[::1]:80/foo/bar?x=1&y=2', url)
+
+    def test_create_url_ipv6_full(self):
+        url = utils.create_url('/foo/bar?x=1&y=2',
+                               '2607:f8b0:4000:801::200e', port=8080)
+        self.assertEqual(
+            'http://[2607:f8b0:4000:801::200e]:8080/foo/bar?x=1&y=2', url)
+
+    def test_create_url_ipv6_already_bracket(self):
+        url = utils.create_url(
+            '/foo/bar?x=1&y=2', '[2607:f8b0:4000:801::200e]', port=999)
+        self.assertEqual(
+            'http://[2607:f8b0:4000:801::200e]:999/foo/bar?x=1&y=2', url)
+
+    def test_create_url_no_double_colon(self):
+        url = utils.create_url(
+            '/foo', 'FEDC:BA98:7654:3210:FEDC:BA98:7654:3210', port=999)
+        self.assertEqual(
+            'http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:999/foo', url)

--- a/gabbi/utils.py
+++ b/gabbi/utils.py
@@ -29,10 +29,17 @@ from six.moves.urllib import parse as urlparse
 def create_url(base_url, host, port=None, prefix='', ssl=False):
     """Given pieces of a path-based url, return a fully qualified url."""
     scheme = 'http'
-    netloc = host
+
+    # A host with : in it at this stage is assumed to be an IPv6
+    # address of some kind (they come in many forms). Port should
+    # already have been stripped off.
+    if ':' in host and not (host.startswith('[') and host.endswith(']')):
+        host = '[%s]' % host
 
     if port and not _port_follows_standard(port, ssl):
         netloc = '%s:%s' % (host, port)
+    else:
+        netloc = host
 
     if ssl:
         scheme = 'https'


### PR DESCRIPTION
According to rfc 2732 an IPv6 address in a url needs to be enclosed
in [] (e.g. http://[::1]/foobar). Gabbi was not doing this. Instead
it was passing host information directly to its URL generation
routine and just using it. When doing tests against real servers
running on ipv6, this results in failures.

The changes here try to do the bare minumum to get the right results
without changing the create_url method too much. It's likely that in
some future version of gabbi we will want to change a lot here (the
current orientation towards hosts and ports instead of URLs is the
result of the wsgi-intercept integration) but for now we want to
keep the change limited.

I hate myself for the mocks in test_runner. A clear sign of bad
abstraction in runner.py, however this is not the place to be
changing that. Another item for the later list.

Fixes #136