### PR TITLE
Allow regex in json path values

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -157,6 +157,11 @@ Response Expectations
                                    content type of ``application/json``
                                    or containing ``+json``)
 
+                                   If the value is wrapped in ``/.../``
+                                   the result of the JSONPath query
+                                   will be compared against the
+                                   value as a regular expression.
+
    ``poll``                        A dictionary of two keys:
 
                                    * ``count``: An integer stating the

--- a/gabbi/handlers.py
+++ b/gabbi/handlers.py
@@ -106,8 +106,18 @@ class JSONResponseHandler(ResponseHandler):
             raise AssertionError('json path %s cannot match %s' %
                                  (path, test.json_data))
         expected = test.replace_template(value)
-        test.assertEqual(expected, match, 'Unable to match %s as %s, got %s'
-                         % (path, expected, match))
+        # If expected is a string, check to see if it is a regex.
+        if (hasattr(expected, 'startswith') and expected.startswith('/')
+                and expected.endswith('/')):
+            expected = expected.strip('/').rstrip('/')
+            test.assertRegexpMatches(
+                match, expected,
+                'Expect jsonpath %s to match /%s/, got %s' %
+                (path, expected, match))
+        else:
+            test.assertEqual(expected, match,
+                             'Unable to match %s as %s, got %s' %
+                             (path, expected, match))
 
 
 class ForbiddenHeadersResponseHandler(ResponseHandler):

--- a/gabbi/tests/gabbits_intercept/regex.yaml
+++ b/gabbi/tests/gabbits_intercept/regex.yaml
@@ -1,8 +1,19 @@
-# Confirm regex handling in response headers
+# Confirm regex handling in response and json path headers
 tests:
-- name: regex test
+- name: regex header test
   url: /cow?alpha=1
   method: PUT
   response_headers:
       x-gabbi-url: /cow\?al.*=1/
       location: $SCHEME://$NETLOC/cow?alpha=1
+
+- name: regex jsonpath test
+  PUT: /cow
+  request_headers:
+    content-type: application/json
+  data:
+    alpha: cow
+    beta: pig
+  response_json_paths:
+    $.alpha: /ow$/
+    $.beta: /(?!cow).*/


### PR DESCRIPTION
If the value of jsonpath entry is a string and is wrapped in /.../
then the matching of the results of the jsonpath will be check via
the regex.

Fixes #146 

/cc @FND @josdotso 