### PR TITLE
Add retype_numerals parameter to replace_template

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -139,7 +139,7 @@ class HTTPTestCase(unittest.TestCase):
             self.prior.run(result.TestResult())
         self._run_test()
 
-    def replace_template(self, message, make_numbers=False):
+    def replace_template(self, message, retype_numerals=False):
         """Replace magic strings in message."""
         if isinstance(message, dict):
             for k in message:
@@ -162,7 +162,7 @@ class HTTPTestCase(unittest.TestCase):
                         raise AssertionError(
                             'unable to replace %s in %s, data unavailable: %s'
                             % (template, message, exc))
-                    if make_numbers:
+                    if retype_numerals:
                         try:
                             if '.' in message:
                                 message = float(message)
@@ -389,8 +389,12 @@ class HTTPTestCase(unittest.TestCase):
             body = ''
 
         if test['poll']:
-            count = test['poll'].get('count', 1)
-            delay = test['poll'].get('delay', 1)
+            count = self.replace_template(test['poll'].get('count', 1),
+                                          retype_numerals=True)
+            delay = self.replace_template(test['poll'].get('delay', 1),
+                                          retype_numerals=True)
+            # Count must be an int, even if it came in as a float
+            count = int(count)
             failure = None
             while count:
                 try:
@@ -433,7 +437,7 @@ class HTTPTestCase(unittest.TestCase):
                 else:
                     return info
         else:
-            data = self.replace_template(data, make_numbers=True)
+            data = self.replace_template(data, retype_numerals=True)
             return json.dumps(data)
         return self.replace_template(data)
 

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -143,12 +143,14 @@ class HTTPTestCase(unittest.TestCase):
         """Replace magic strings in message."""
         if isinstance(message, dict):
             for k in message:
-                message[k] = self.replace_template(message[k])
+                message[k] = self.replace_template(message[k],
+                                                   retype_numerals)
             return message
         if isinstance(message, list):
             new_message = []
             for line in message:
-                new_message.append(self.replace_template(line))
+                new_message.append(
+                    self.replace_template(line, retype_numerals))
             return new_message
 
         for replacer in REPLACERS:

--- a/gabbi/handlers.py
+++ b/gabbi/handlers.py
@@ -105,7 +105,7 @@ class JSONResponseHandler(ResponseHandler):
         except ValueError:
             raise AssertionError('json path %s cannot match %s' %
                                  (path, test.json_data))
-        expected = test.replace_template(value)
+        expected = test.replace_template(value, retype_numerals=True)
         # If expected is a string, check to see if it is a regex.
         if (hasattr(expected, 'startswith') and expected.startswith('/')
                 and expected.endswith('/')):

--- a/gabbi/tests/gabbits_intercept/poll.yaml
+++ b/gabbi/tests/gabbits_intercept/poll.yaml
@@ -26,7 +26,7 @@ tests:
 
     # Confirm that $LOCATION and $RESPONSE behave in poll.
     - name: create a thing
-      url: /poller?count=2&x=1&y=2
+      url: /poller?count=2&x=1&y=2&z=3.4
       method: POST
       request_headers:
           content-type: application/json
@@ -36,13 +36,14 @@ tests:
       response_json_paths:
           $.x[0]: '1'
           $.y[0]: '2'
+          $.z[0]: '3.4'
 
 
     - name: loop location
       url: $LOCATION
       verbose: True
       poll:
-          count: 3
+          count: $RESPONSE['$.z[0]']
           delay: .01
       response_json_paths:
           $.x[0]: $RESPONSE['$.x[0]']

--- a/gabbi/tests/gabbits_intercept/poll.yaml
+++ b/gabbi/tests/gabbits_intercept/poll.yaml
@@ -34,14 +34,13 @@ tests:
           count: 3
           delay: .01
       response_json_paths:
-          $.x[0]: '1'
-          $.y[0]: '2'
-          $.z[0]: '3.4'
+          $.x[0]: 1
+          $.y[0]: 2
+          $.z[0]: 3.4
 
 
     - name: loop location
       url: $LOCATION
-      verbose: True
       poll:
           count: $RESPONSE['$.z[0]']
           delay: .01

--- a/gabbi/tests/gabbits_intercept/queryparams.yaml
+++ b/gabbi/tests/gabbits_intercept/queryparams.yaml
@@ -31,8 +31,8 @@ tests:
           x-gabbi-url: $SCHEME://$NETLOC/foo?bar=1&bar=2
           content-type: application/json
       response_json_paths:
-          $.bar[0]: "1"
-          $.bar[1]: "2"
+          $.bar[0]: 1
+          $.bar[1]: 2
 
     - name: replacers in params
       url: /foo

--- a/gabbi/tests/gabbits_intercept/self.yaml
+++ b/gabbi/tests/gabbits_intercept/self.yaml
@@ -21,9 +21,9 @@ tests:
   response_headers:
       x-gabbi-url: $SCHEME://$NETLOC/cow?alpha=1
   response_strings:
-      - '"alpha": ["1"]'
+      - '"alpha": [1]'
   response_json_paths:
-      alpha[0]: "1"
+      alpha[0]: 1
 
 - name: bogus method
   url: /
@@ -37,11 +37,11 @@ tests:
 - name: query returned
   url: /somewhere?foo=1&bar=2&bar=3
   response_strings:
-      - "\"bar\": [\"2\", \"3\"]"
+      - "\"bar\": [2, 3]"
   response_json_paths:
       bar:
-          - "2"
-          - "3"
+          - 2
+          - 3
 
 - name: simple post
   url: /named/thing
@@ -109,7 +109,7 @@ tests:
 - name: test pluggable response
   url: /foo?alpha=1
   response_test:
-      - 'COW"alpha": ["1"]'
+      - 'COW"alpha": [1]'
       - COWAnother line
 
 - name: fail pluggable response
@@ -117,7 +117,7 @@ tests:
   url: /foo?alpha=1
   xfail: true
   response_test:
-      - 'CO"alpha": ["1"]'
+      - 'CO"alpha": [1]'
 
 - name: test exception wrapper
   desc: simple wsgi will raise exception

--- a/gabbi/tests/simple_wsgi.py
+++ b/gabbi/tests/simple_wsgi.py
@@ -55,6 +55,20 @@ class SimpleWsgi(object):
             ('X-Gabbi-url', full_request_url),
         ]
 
+        # clean up numbers in query_data
+        cleaned_query = {}
+        for key, values in query_data.items():
+            newvalues = []
+            for item in values:
+                try:
+                    item = float(item) if '.' in item else int(item)
+                except (ValueError, TypeError):
+                    pass
+                newvalues.append(item)
+            cleaned_query[key] = newvalues
+
+        query_data = cleaned_query
+
         if request_method == 'DIE':
             raise Exception('because you asked me to')
 


### PR DESCRIPTION
When replace_template is used against the value of a test key there are
contexts within which if the value looks like a number it should be treated
as a number. For example when creating JSON from the `data` key.

A retype_numerals parameter has been added to replace_template which,
when true, will attempt to turn something that looks like a float or int into
a float or int.

Fixes #147 
Fixes #150 
