### PR TITLE
Cast json match to string when doing regex match

### DIFF
--- a/gabbi/handlers.py
+++ b/gabbi/handlers.py
@@ -110,6 +110,8 @@ class JSONResponseHandler(ResponseHandler):
         if (hasattr(expected, 'startswith') and expected.startswith('/')
                 and expected.endswith('/')):
             expected = expected.strip('/').rstrip('/')
+            # match may be a number so stringify
+            match = str(match)
             test.assertRegexpMatches(
                 match, expected,
                 'Expect jsonpath %s to match /%s/, got %s' %

--- a/gabbi/tests/gabbits_intercept/regex.yaml
+++ b/gabbi/tests/gabbits_intercept/regex.yaml
@@ -14,6 +14,8 @@ tests:
   data:
     alpha: cow
     beta: pig
+    gamma: 1
   response_json_paths:
     $.alpha: /ow$/
     $.beta: /(?!cow).*/
+    $.gamma: /\d+/

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -128,6 +128,34 @@ class HandlersTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self._assert_handler(handler)
 
+    def test_response_json_paths_regex(self):
+        handler = handlers.JSONResponseHandler(self.test_class)
+        self.test.content_type = "application/json"
+        self.test.test_data = {'response_json_paths': {
+            '$.objects[0].name': '/ow/',
+        }}
+        self.test.json_data = {
+            'objects': [{'name': 'cow',
+                         'location': 'barn'},
+                        {'name': 'chris',
+                         'location': 'house'}]
+        }
+        self._assert_handler(handler)
+
+    def test_response_json_paths_regex_number(self):
+        handler = handlers.JSONResponseHandler(self.test_class)
+        self.test.content_type = "application/json"
+        self.test.test_data = {'response_json_paths': {
+            '$.objects[0].name': '/\d+/',
+        }}
+        self.test.json_data = {
+            'objects': [{'name': 99,
+                         'location': 'barn'},
+                        {'name': 'chris',
+                         'location': 'house'}]
+        }
+        self._assert_handler(handler)
+
     def test_response_headers(self):
         handler = handlers.HeadersResponseHandler(self.test_class)
         self.test.response = {'content-type': 'text/plain'}


### PR DESCRIPTION
Otherwise a TypeError can happen. Tests are added to insure it works
as expected.

Fixes #166 

/cc @FND @jasonamyers 