### PR TITLE
Add a custom move to six to make mock available for both Python 2 and 3.

### DIFF
--- a/gabbi/tests/__init__.py
+++ b/gabbi/tests/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import six
+
+six.add_move(six.MovedModule('mock', 'mock', 'unittest.mock'))

--- a/gabbi/tests/test_fixtures.py
+++ b/gabbi/tests/test_fixtures.py
@@ -13,7 +13,7 @@
 """Use mocks to confirm that fixtures operate as context managers.
 """
 
-import mock
+from six.moves import mock
 import unittest
 
 from gabbi import fixture

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-mock
+mock ; python_version < '3.3'
 testrepository
 coverage
 hacking


### PR DESCRIPTION
Fixes #168