### PR TITLE
Allow test_loader_name to override test class module

### DIFF
--- a/gabbi/suitemaker.py
+++ b/gabbi/suitemaker.py
@@ -36,7 +36,8 @@ class TestMaker(object):
     """
 
     def __init__(self, test_base_name, test_defaults, test_directory,
-                 fixture_classes, loader, host, port, intercept, prefix):
+                 fixture_classes, loader, host, port, intercept, prefix,
+                 test_loader_name=None):
         self.test_base_name = test_base_name
         self.test_defaults = test_defaults
         self.default_keys = set(test_defaults.keys())
@@ -47,6 +48,7 @@ class TestMaker(object):
         self.loader = loader
         self.intercept = intercept
         self.prefix = prefix
+        self.test_loader_name = test_loader_name
 
     def make_one_test(self, test_dict, prior_test):
         """Create one single HTTPTestCase.
@@ -87,6 +89,10 @@ class TestMaker(object):
                              'port': self.port,
                              'prefix': self.prefix,
                              'prior': prior_test})
+        # We've been asked to, make this test class think it comes
+        # from a different module.
+        if self.test_loader_name:
+            klass.__module__ = self.test_loader_name
 
         tests = self.loader.loadTestsFromTestCase(klass)
         # Return the first (and only) test in the klass.
@@ -157,7 +163,8 @@ class TestBuilder(type):
 
 
 def test_suite_from_dict(loader, test_base_name, suite_dict, test_directory,
-                         host, port, fixture_module, intercept, prefix=''):
+                         host, port, fixture_module, intercept, prefix='',
+                         test_loader_name=None):
     """Generate a GabbiSuite from a dict represent a list of tests.
 
     The dict takes the form:
@@ -193,7 +200,7 @@ def test_suite_from_dict(loader, test_base_name, suite_dict, test_directory,
 
     test_maker = TestMaker(test_base_name, default_test_dict, test_directory,
                            fixture_classes, loader, host, port, intercept,
-                           prefix)
+                           prefix, test_loader_name)
     file_suite = suite.GabbiSuite()
     prior_test = None
     for test_dict in test_data:

--- a/gabbi/tests/test_intercept.py
+++ b/gabbi/tests/test_intercept.py
@@ -69,6 +69,7 @@ def load_tests(loader, tests, pattern):
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
     return driver.build_tests(test_dir, loader, host=None,
                               intercept=simple_wsgi.SimpleWsgi,
+                              test_loader_name=__name__,
                               prefix=prefix,
                               fixture_module=sys.modules[__name__],
                               response_handlers=[TestResponseHandler])

--- a/test-limit.sh
+++ b/test-limit.sh
@@ -6,7 +6,7 @@
 # This covers a situation where the change of intercepts to fixtures
 # broke limiting tests and we never knew.
 
-GREP_TEST_MATCH='gabbi.suitemaker.test_intercept_self_checklimit.test_request ... ok'
+GREP_TEST_MATCH='tests.test_intercept.self_checklimit.test_request ... ok'
 GREP_COUNT_MATCH='Ran 1 '
 
 python setup.py testr --testr-args="checklimit" && \


### PR DESCRIPTION
When running gabbi by default the pretty name of the test
(displayed in test results) has a 'gabbi.suitemaker' prefix. This
can be disorienting when reviewing result sets or trying to track
those results to where in a code tree the gabbi tests are loaded.

This change allows the __module__ of the test classes that are
dynamically created to be override with the test_loader_name
that is passed in to to the build_tests method. By setting this
to __name__ the test is appropriately situated in its context. The
gist of this change can be seen on the diff to test-limit.sh.

Note that this has also been tested in OpenStack Nova, which
was the source of this need. There tests which were showing up with
the name:

    gabbi.suitemaker.test_placement_api_inventory_get_that_inventory.\
      test_request

have become:

    nova.tests.functional.api.openstack.placement.\
      test_placement_api.inventory_get_that_inventory.test_request

By default nothing has changed. This change only impact situations where
test_loader_name is used.

/cc @FND @jasonamyers @sdague