### PR TITLE
Verbose post bug

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -360,7 +360,7 @@ class HTTPTestCase(testtools.TestCase):
                 raise exception.GabbiFormatError(
                     'malformed headers in test %s: %s' % (test['name'], exc))
 
-        if test['data'] is not '':
+        if test['data'] != '':
             body = self._test_data_to_string(
                 test['data'],
                 utils.extract_content_type(headers, default='')[0])

--- a/gabbi/tests/test_verbose.yaml
+++ b/gabbi/tests/test_verbose.yaml
@@ -1,0 +1,9 @@
+tests:
+
+  - name: POST data with verbose true
+    verbose: true
+    POST: /
+    request_headers:
+        content-type: application/json
+    data:
+        'text'

--- a/gabbi/utils.py
+++ b/gabbi/utils.py
@@ -15,6 +15,7 @@
 import io
 import os
 
+import six
 import yaml
 
 
@@ -62,7 +63,7 @@ def decode_response_content(header_dict, content):
     """Decode content to a proper string."""
     content_type, charset = extract_content_type(header_dict)
 
-    if not_binary(content_type):
+    if not_binary(content_type) and isinstance(content, six.binary_type):
         return content.decode(charset)
     else:
         return content


### PR DESCRIPTION
`VerboseHttp` is printing the request and response via `utils.decode_response_content`.

`decode_response_content` expects its input to require decoding, if the content_type is non-binary. However the POST body data is already decoded into a string, so decoding again fails.

```shell
E POST data with verbose true

ERROR: POST data with verbose true
	Traceback (most recent call last):
	  File "/home/tom/dev/gabbi/gabbi/case.py", line 92, in wrapper
	    func(self)
	  File "/home/tom/dev/gabbi/gabbi/case.py", line 140, in test_request
	    self._run_test()
	  File "/home/tom/dev/gabbi/gabbi/case.py", line 391, in _run_test
	    redirect=test['redirects'])
	  File "/home/tom/dev/gabbi/gabbi/case.py", line 322, in _run_request
	    redirect=redirect
	  File "/home/tom/dev/gabbi/gabbi/httpclient.py", line 113, in request
	    self._print_body(headers, body)
	  File "/home/tom/dev/gabbi/gabbi/httpclient.py", line 145, in _print_body
	    utils.decode_response_content(headers, content))
	  File "/home/tom/dev/gabbi/gabbi/utils.py", line 67, in decode_response_content
	    return content.decode(charset)
	AttributeError: 'str' object has no attribute 'decode'
----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```