### PR TITLE
Pretty print JSON bodies in verbose tests

### DIFF
--- a/gabbi/httpclient.py
+++ b/gabbi/httpclient.py
@@ -19,6 +19,7 @@ import sys
 
 import urllib3
 
+from gabbi.handlers import jsonhandler
 from gabbi import utils
 
 
@@ -138,11 +139,20 @@ class VerboseHttp(Http):
 
     def _print_body(self, headers, content):
         """Output body if not binary."""
-        if self._show_body and utils.not_binary(
-                utils.extract_content_type(headers)[0]):
+        content_type = utils.extract_content_type(headers)[0]
+        if self._show_body and utils.not_binary(content_type):
+            content = utils.decode_response_content(headers, content)
+            # TODO(cdent): Using the JSONHandler here instead of
+            # just the json module to make it clear that eventually
+            # we could pretty print any printable output by using a
+            # handler's loads() and dumps(). Not doing that now
+            # because it would be pointless (no other interesting
+            # handlers) and this may approach may be entirely wrong.
+            if jsonhandler.JSONHandler.accepts(content_type):
+                data = jsonhandler.JSONHandler.loads(content)
+                content = jsonhandler.JSONHandler.dumps(data, pretty=True)
             self._verbose_output('')
-            self._verbose_output(
-                utils.decode_response_content(headers, content))
+            self._verbose_output(content)
 
     def _print_header(self, name, value, prefix='', stream=None):
         """Output one single header."""

--- a/gabbi/httpclient.py
+++ b/gabbi/httpclient.py
@@ -147,7 +147,7 @@ class VerboseHttp(Http):
             # we could pretty print any printable output by using a
             # handler's loads() and dumps(). Not doing that now
             # because it would be pointless (no other interesting
-            # handlers) and this may approach may be entirely wrong.
+            # handlers) and this approach may be entirely wrong.
             if jsonhandler.JSONHandler.accepts(content_type):
                 data = jsonhandler.JSONHandler.loads(content)
                 content = jsonhandler.JSONHandler.dumps(data, pretty=True)

--- a/gabbi/tests/gabbits_runner/test_verbose.yaml
+++ b/gabbi/tests/gabbits_runner/test_verbose.yaml
@@ -1,0 +1,18 @@
+tests:
+
+- name: POST data with verbose true
+  verbose: true
+  POST: /
+  request_headers:
+    content-type: application/json
+  data:
+    - our text
+
+- name: structured data
+  verbose: true
+  POST: /
+  request_headers:
+      content-type: application/json
+  data:
+     cow: moo
+     dog: bark

--- a/gabbi/tests/test_runner.py
+++ b/gabbi/tests/test_runner.py
@@ -228,6 +228,27 @@ class RunnerTest(unittest.TestCase):
             except SystemExit as err:
                 self.assertSuccess(err)
 
+    def test_verbose_output_formatting(self):
+        """Confirm that a verbose test handles output properly."""
+        sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port)]
+
+        sys.argv.append('--')
+        sys.argv.append('gabbi/tests/gabbits_runner/test_verbose.yaml')
+        with self.server():
+            try:
+                runner.run()
+            except SystemExit as err:
+                self.assertSuccess(err)
+
+        sys.stdout.seek(0)
+        output = sys.stdout.read()
+        self.assertIn('"our text"', output)
+        self.assertIn('"cow": "moo"', output)
+        self.assertIn('"dog": "bark"', output)
+        # confirm pretty printing
+        self.assertIn('{\n', output)
+        self.assertIn('}\n', output)
+
     def assertSuccess(self, exitError):
         errors = exitError.args[0]
         if errors:

--- a/gabbi/tests/test_verbose.yaml
+++ b/gabbi/tests/test_verbose.yaml
@@ -1,9 +1,0 @@
-tests:
-
-  - name: POST data with verbose true
-    verbose: true
-    POST: /
-    request_headers:
-        content-type: application/json
-    data:
-        'text'


### PR DESCRIPTION
If a request or response body is JSON, then use the loads and dumps
methods on the JSON content handler to present it in a pretty
fashion. See the TODO in gabbi/httpclient.py for future expansion
options.

This reuses a test_verbose.yaml file added in pull request #183
that didn't seem to be doing anything.

Tests for this are in test_runner.py as it provides useful stdout
capturing infrastructure.

Fixes #182