### PR TITLE
Fix pytest yield

### DIFF
--- a/docs/source/loader.rst
+++ b/docs/source/loader.rst
@@ -67,7 +67,35 @@ pytest
 .. _pytest_loader:
 
 Since pytest does not support the ``load_tests`` system, a different
-way of generating tests is required. A test file must be created
+way of generating tests is required. Two techniques are supported.
+
+The original method (described below) used yield statements to
+generate tests which pytest would collect. This style of tests is
+deprecated as of ``pytest>=3.0`` so a new style using pytest
+fixtures has been developed.
+
+pytest >= 3.0
+-------------
+
+In the newer technique, a test file is created that uses the
+``pytest_generate_tests`` hook. Special care must be taken to always
+import the ``test_pytest`` method which is the base test that the
+pytest hook parametrizes to generate the tests from the YAML files.
+Without the method, the hook will not be called and no tests generated.
+
+Here is a simple example file:
+
+.. literalinclude:: pytest3.0-example.py
+   :language: python
+
+This can then be run with the usual pytest commands. For example::
+
+   py.test -svx pytest3.0-example.py
+
+pytest < 3.0
+------------
+
+When using the older technique, test file must be created
 that calls :meth:`~gabbi.driver.py_test_generator` and yields the
 generated tests. That will look a bit like this:
 
@@ -78,14 +106,11 @@ This can then be run with the usual pytest commands. For example::
 
    py.test -svx pytest-example.py
 
-.. warning:: In ``pytest>=3.0`` yield tests are deprecated and using
-             them will cause pytest to produce a warning. If you
-             wish to ignore and hide these warnings add the
-             ``--disable-pytest-warnings`` parameter to the
-             invocation of ``py.test`` or use a version of pytest
-             earlier than version ``3.0``. A new way of creating gabbi
-             tests that works more effectively with modern pytest is
-             being developed.
+The older technique will continue to work with all versions of
+``pytest<4.0`` but ``>=3.0`` will produce warnings. If you want to
+use the older technique but not see the warnings add
+``--disable-pytest-warnings`` parameter to the invocation of
+``py.test``.
 
 .. _source distribution: https://github.com/cdent/gabbi
 .. _the tutorial repo: https://github.com/cdent/gabbi-demo

--- a/docs/source/pytest3.0-example.py
+++ b/docs/source/pytest3.0-example.py
@@ -1,0 +1,30 @@
+"""A sample pytest module for pytest >= 3.0."""
+
+# For pathname munging
+import os
+
+# The module that py_test_generator comes from.
+from gabbi import driver
+
+# We need test_pytest so that pytest test collection works properly.
+# Without this, the pytest_generate_tests method below will not be
+# called.
+from gabbi.driver import test_pytest  # noqa
+
+# We need access to the WSGI application that hosts our service
+from myapp import wsgiapp
+
+# We're using fixtures in the YAML files, we need to know where to
+# load them from.
+from myapp.test import fixtures
+
+# By convention the YAML files are put in a directory named
+# "gabbits" that is in the same directory as the Python test file.
+TESTS_DIR = 'gabbits'
+
+
+def pytest_generate_tests(metafunc):
+    test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
+    driver.py_test_generator(
+        test_dir, intercept=wsgiapp.app,
+        fixture_module=fixtures, metafunc=metafunc)

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -170,7 +170,7 @@ def py_test_generator(test_dir, host=None, port=8001, intercept=None,
             ids = []
             args = []
             for test in test_list:
-                if len(test) >=3:
+                if len(test) >= 3:
                     name, method, arg = test
                 else:
                     name, method = test
@@ -185,9 +185,9 @@ def py_test_generator(test_dir, host=None, port=8001, intercept=None,
 
 
 def test_pytest(test, result):
-    try:
+    if result:
         test(result)
-    except TypeError:
+    else:
         test()
 
 

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -129,7 +129,8 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
 def py_test_generator(test_dir, host=None, port=8001, intercept=None,
                       prefix=None, test_loader_name=None,
                       fixture_module=None, response_handlers=None,
-                      content_handlers=None, require_ssl=False, url=None):
+                      content_handlers=None, require_ssl=False, url=None,
+                      metafunc=None):
     """Generate tests cases for py.test
 
     This uses build_tests to create TestCases and then yields them in
@@ -156,16 +157,33 @@ def py_test_generator(test_dir, host=None, port=8001, intercept=None,
         if hasattr(test, '_tests'):
             # Establish fixtures as if they were tests. These will
             # be cleaned up by the pytester plugin.
-            test_list.append(('start_%s' % test._tests[0].__class__.__name__, test.start, result))
+            test_list.append(('start_%s' % test._tests[0].__class__.__name__,
+                              test.start, result))
             for subtest in test:
-                test_list.append(('%s' % subtest.__class__.__name__, subtest, result))
-            test_list.append(('stop_%s' % test._tests[0].__class__.__name__, test.stop))
+                test_list.append(('%s' % subtest.__class__.__name__,
+                                  subtest, result))
+            test_list.append(('stop_%s' % test._tests[0].__class__.__name__,
+                              test.stop))
 
-    return test_list
+    if metafunc:
+        if metafunc.function == test_pytest:
+            ids = []
+            args = []
+            for test in test_list:
+                if len(test) >=3:
+                    name, method, arg = test
+                else:
+                    name, method = test
+                    arg = None
+                ids.append(name)
+                args.append((method, arg))
+
+            metafunc.parametrize("test, result", argvalues=args, ids=ids)
+    else:
+        # preserve backwards compatibility with old calling style
+        return test_list
 
 
-# temporarily here for testing, there has to be some kind of test
-# that is being parameterized.
 def test_pytest(test, result):
     try:
         test(result)

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -151,15 +151,26 @@ def py_test_generator(test_dir, host=None, port=8001, intercept=None,
                         prefix=prefix, require_ssl=require_ssl,
                         url=url)
 
+    test_list = []
     for test in tests:
         if hasattr(test, '_tests'):
             # Establish fixtures as if they were tests. These will
             # be cleaned up by the pytester plugin.
-            yield 'start_%s' % test._tests[0].__class__.__name__, \
-                test.start, result
+            test_list.append(('start_%s' % test._tests[0].__class__.__name__, test.start, result))
             for subtest in test:
-                yield '%s' % subtest.__class__.__name__, subtest, result
-            yield 'stop_%s' % test._tests[0].__class__.__name__, test.stop
+                test_list.append(('%s' % subtest.__class__.__name__, subtest, result))
+            test_list.append(('stop_%s' % test._tests[0].__class__.__name__, test.stop))
+
+    return test_list
+
+
+# temporarily here for testing, there has to be some kind of test
+# that is being parameterized.
+def test_pytest(test, result):
+    try:
+        test(result)
+    except TypeError:
+        test()
 
 
 def test_suite_from_yaml(loader, test_base_name, test_yaml, test_directory,

--- a/gabbi/tests/test_gabbits_pytest.py
+++ b/gabbi/tests/test_gabbits_pytest.py
@@ -19,9 +19,9 @@ without duplication.
 
 import os
 
-# TODO: this test_* needs to be imported bare or things do not work
-from gabbi.driver import test_pytest
 from gabbi import driver
+# TODO(cdent): this test_* needs to be imported bare or things do not work
+from gabbi.driver import test_pytest  # noqa
 from gabbi.tests import simple_wsgi
 from gabbi.tests import test_intercept
 

--- a/gabbi/tests/test_gabbits_pytest.py
+++ b/gabbi/tests/test_gabbits_pytest.py
@@ -19,9 +19,9 @@ without duplication.
 
 import os
 
-from gabbi import driver
-# this test_* needs to be imported bare or things do not work
+# TODO: this test_* needs to be imported bare or things do not work
 from gabbi.driver import test_pytest
+from gabbi import driver
 from gabbi.tests import simple_wsgi
 from gabbi.tests import test_intercept
 
@@ -29,25 +29,10 @@ TESTS_DIR = 'gabbits_intercept'
 
 
 def pytest_generate_tests(metafunc):
-
     os.environ['GABBI_TEST_URL'] = 'takingnames'
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
-    test_generator = driver.py_test_generator(
+    driver.py_test_generator(
         test_dir, intercept=simple_wsgi.SimpleWsgi,
         fixture_module=test_intercept,
-        response_handlers=[test_intercept.TestResponseHandler])
-
-    if metafunc.function == test_pytest:
-
-        ids = []
-        args = []
-        for test in test_generator:
-            if len(test) >=3:
-                name, method, arg = test
-            else:
-                name, method = test
-                arg = None
-            ids.append(name)
-            args.append((method, arg))
-
-        metafunc.parametrize("test, result", argvalues=args, ids=ids)
+        response_handlers=[test_intercept.TestResponseHandler],
+        metafunc=metafunc)

--- a/gabbi/tests/test_gabbits_pytest.py
+++ b/gabbi/tests/test_gabbits_pytest.py
@@ -20,13 +20,15 @@ without duplication.
 import os
 
 from gabbi import driver
+# this test_* needs to be imported bare or things do not work
+from gabbi.driver import test_pytest
 from gabbi.tests import simple_wsgi
 from gabbi.tests import test_intercept
 
 TESTS_DIR = 'gabbits_intercept'
 
 
-def test_from_build():
+def pytest_generate_tests(metafunc):
 
     os.environ['GABBI_TEST_URL'] = 'takingnames'
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
@@ -35,7 +37,17 @@ def test_from_build():
         fixture_module=test_intercept,
         response_handlers=[test_intercept.TestResponseHandler])
 
-    # TODO(cdent): Where is our Python3!
-    # yield from test_generator
-    for test in test_generator:
-        yield test
+    if metafunc.function == test_pytest:
+
+        ids = []
+        args = []
+        for test in test_generator:
+            if len(test) >=3:
+                name, method, arg = test
+            else:
+                name, method = test
+                arg = None
+            ids.append(name)
+            args.append((method, arg))
+
+        metafunc.parametrize("test, result", argvalues=args, ids=ids)


### PR DESCRIPTION
This branch is an effort to fix the warnings caused by yield tests as introduced by pytest 3.0. It changes over to a method suggested on the [pytest-dev list](https://mail.python.org/pipermail/pytest-dev/2016-October/003907.html). That strategy has been made to work (while maintaining ackwards compatibility with existing test suites), but it still requires having the caller import the `test_pytest` function (on which the fixture generation tooling operated) along with creating a `pytest_generate_tests` function. (see the `gabbi/tests/test_gabbits_pytest.py` file for the entrypoint).

This is more cumbersome than desired and a bit hard to document/explain but I'm not sure what to do. So, to increase visibility I'm pulling the branch into a pull request that's not ready but needs help and cc'ing the current active contributors for additional opinions (please and thank you).

/cc @FND @jasonamyers @tomviner 