### PR TITLE
Use the dirname of each runner testfile as the test_dir

### DIFF
--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -14,6 +14,7 @@
 
 import argparse
 from importlib import import_module
+import os
 import sys
 import unittest
 
@@ -84,8 +85,9 @@ def run():
     else:
         for input_file in input_files:
             with open(input_file, 'r') as fh:
+                data_dir = os.path.dirname(input_file)
                 success = run_suite(fh, handler_objects, host, port,
-                                    prefix, force_ssl, failfast)
+                                    prefix, force_ssl, failfast, data_dir)
             if not failure:  # once failed, this is considered immutable
                 failure = not success
             if failure and failfast:
@@ -95,7 +97,7 @@ def run():
 
 
 def run_suite(handle, handler_objects, host, port, prefix, force_ssl=False,
-              failfast=False):
+              failfast=False, data_dir='.'):
     """Run the tests from the YAML in handle."""
     data = utils.load_yaml(handle)
     if force_ssl:
@@ -106,7 +108,7 @@ def run_suite(handle, handler_objects, host, port, prefix, force_ssl=False,
 
     loader = unittest.defaultTestLoader
     test_suite = suitemaker.test_suite_from_dict(
-        loader, 'input', data, '.', host, port, None, None, prefix=prefix,
+        loader, 'input', data, data_dir, host, port, None, None, prefix=prefix,
         handlers=handler_objects)
 
     result = ConciseTestRunner(

--- a/gabbi/tests/gabbits_runner/subdir/sample.json
+++ b/gabbi/tests/gabbits_runner/subdir/sample.json
@@ -1,0 +1,1 @@
+{"items": {"house": "blue"}}

--- a/gabbi/tests/gabbits_runner/test_data.yaml
+++ b/gabbi/tests/gabbits_runner/test_data.yaml
@@ -1,0 +1,8 @@
+tests:
+
+- name: POST data from file
+  verbose: true
+  POST: /
+  request_headers:
+    content-type: application/json
+  data: <@subdir/sample.json

--- a/gabbi/tests/test_runner.py
+++ b/gabbi/tests/test_runner.py
@@ -22,6 +22,7 @@ from wsgi_intercept.interceptor import Urllib3Interceptor
 
 from gabbi import exception
 from gabbi.handlers import base
+from gabbi.handlers.jsonhandler import JSONHandler
 from gabbi import runner
 from gabbi.tests.simple_wsgi import SimpleWsgi
 
@@ -248,6 +249,28 @@ class RunnerTest(unittest.TestCase):
         # confirm pretty printing
         self.assertIn('{\n', output)
         self.assertIn('}\n', output)
+
+    def test_data_dir_good(self):
+        """Confirm that data dir is the test file's dir."""
+        sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port)]
+
+        sys.argv.append('--')
+        sys.argv.append('gabbi/tests/gabbits_runner/test_data.yaml')
+        with self.server():
+            try:
+                runner.run()
+            except SystemExit as err:
+                self.assertSuccess(err)
+
+        # Compare the verbose output of tests with pretty printed
+        # data.
+        with open('gabbi/tests/gabbits_runner/subdir/sample.json') as data:
+            data = JSONHandler.loads(data.read())
+            expected_string = JSONHandler.dumps(data, pretty=True)
+
+        sys.stdout.seek(0)
+        output = sys.stdout.read()
+        self.assertIn(expected_string, output)
 
     def assertSuccess(self, exitError):
         errors = exitError.args[0]


### PR DESCRIPTION
When gabbi-run is passed one or more files, set the working
directory for the associated test suite as the directory of
each test file. Doing so ensures that `<@file` syntax in the
YAML has a fixed point from which to find the data files.

If data comes from STDIN then the test directory is '.' (as
it has always been).

Fixes #184 

/cc @tomviner @FND 