### PR TITLE
Add a -v or --verbose flag to gabbi-run

### DIFF
--- a/docs/source/runner.rst
+++ b/docs/source/runner.rst
@@ -50,3 +50,6 @@ YAML will default to ``ssl: True``.
 
 If a ``-x`` or ``--failfast`` argument is provided then ``gabbi-run`` will
 exit after the first test failure.
+
+Use ``-v`` or ``--verbose`` with a value of ``all``, ``headers`` or ``body``
+to turn on :ref:`verbosity <metadata>` for all tests being run.

--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -57,6 +57,9 @@ def run():
 
         gabbi-run -x example.com:9999 /mountpoint < mytest.yaml
 
+    Use `-v` or `--verbose` with a value of `all`, `headers` or `body` to
+    turn on verbosity for all tests being run.
+
     Multiple files may be named as arguments, separated from other arguments
     by a ``--``. Each file will be run as a separate test suite::
 
@@ -74,18 +77,19 @@ def run():
 
     handler_objects = initialize_handlers(args.response_handlers)
 
+    verbosity = args.verbosity
     failfast = args.failfast
     failure = False
 
     if not input_files:
         success = run_suite(sys.stdin, handler_objects, host, port,
-                            prefix, force_ssl, failfast)
+                            prefix, force_ssl, failfast, verbosity)
         failure = not success
     else:
         for input_file in input_files:
             with open(input_file, 'r') as fh:
                 success = run_suite(fh, handler_objects, host, port,
-                                    prefix, force_ssl, failfast)
+                                    prefix, force_ssl, failfast, verbosity)
             if not failure:  # once failed, this is considered immutable
                 failure = not success
             if failure and failfast:
@@ -95,7 +99,7 @@ def run():
 
 
 def run_suite(handle, handler_objects, host, port, prefix, force_ssl=False,
-              failfast=False):
+              failfast=False, verbosity=False):
     """Run the tests from the YAML in handle."""
     data = utils.load_yaml(handle)
     if force_ssl:
@@ -103,6 +107,11 @@ def run_suite(handle, handler_objects, host, port, prefix, force_ssl=False,
             data['defaults']['ssl'] = True
         else:
             data['defaults'] = {'ssl': True}
+    if verbosity:
+        if 'defaults' in data:
+            data['defaults']['verbose'] = verbosity
+        else:
+            data['defaults'] = {'verbose': verbosity}
 
     loader = unittest.defaultTestLoader
     test_suite = suitemaker.test_suite_from_dict(
@@ -193,6 +202,12 @@ def _make_argparser():
         action='append',
         help='Custom response handler. Should be an import path of the '
              'form package.module or package.module:class.'
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        dest='verbosity',
+        choices=['all', 'body', 'headers'],
+        help='Turn on test verbosity for all tests run in this session.'
     )
     return parser
 

--- a/gabbi/tests/gabbits_runner/verbosity.yaml
+++ b/gabbi/tests/gabbits_runner/verbosity.yaml
@@ -1,0 +1,8 @@
+tests:
+
+- name: simple data post
+  POST: /
+  request_headers:
+    content-type: application/json
+  data:
+    cat: poppy

--- a/gabbi/tests/test_runner.py
+++ b/gabbi/tests/test_runner.py
@@ -249,6 +249,53 @@ class RunnerTest(unittest.TestCase):
         self.assertIn('{\n', output)
         self.assertIn('}\n', output)
 
+    def _run_verbosity_arg(self):
+        sys.argv.append('--')
+        sys.argv.append('gabbi/tests/gabbits_runner/verbosity.yaml')
+        with self.server():
+            try:
+                runner.run()
+            except SystemExit as err:
+                self.assertSuccess(err)
+
+        sys.stdout.seek(0)
+        output = sys.stdout.read()
+        return output
+
+    def test_verbosity_arg_none(self):
+        """Confirm --verbose handling."""
+        sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port)]
+
+        output = self._run_verbosity_arg()
+        self.assertEqual('', output)
+
+    def test_verbosity_arg_body(self):
+        """Confirm --verbose handling."""
+        sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port),
+                    '--verbose=body']
+
+        output = self._run_verbosity_arg()
+        self.assertIn('{\n  "cat": "poppy"\n}', output)
+        self.assertNotIn('application/json', output)
+
+    def test_verbosity_arg_headers(self):
+        """Confirm --verbose handling."""
+        sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port),
+                    '--verbose=headers']
+
+        output = self._run_verbosity_arg()
+        self.assertNotIn('{\n  "cat": "poppy"\n}', output)
+        self.assertIn('application/json', output)
+
+    def test_verbosity_arg_all(self):
+        """Confirm --verbose handling."""
+        sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port),
+                    '--verbose=all']
+
+        output = self._run_verbosity_arg()
+        self.assertIn('{\n  "cat": "poppy"\n}', output)
+        self.assertIn('application/json', output)
+
     def assertSuccess(self, exitError):
         errors = exitError.args[0]
         if errors:


### PR DESCRIPTION
A value of 'all', 'headers' or 'body' will have the expected
effect on all the tests being run in the current testing session.

This is done by manipulating the 'defaults' of each test suite.

Fixes: #185 

/cc @FND @tomviner 