### PR TITLE
gabbi-run: Fix usage of STDIN

### DIFF
--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -84,7 +84,8 @@ def run():
 
     if not input_files:
         success = run_suite(sys.stdin, handler_objects, host, port,
-                            prefix, force_ssl, failfast, verbosity)
+                            prefix, force_ssl, failfast,
+                            verbosity=verbosity)
         failure = not success
     else:
         for input_file in input_files:


### PR DESCRIPTION
Recent change have break gabbi-run with STDIN.
"verbosity" is passed the the "datadir" instead of "."

This fixes that.

Also, I don't get why the test suite doesn't fail.

I have discover the issue here: http://logs.openstack.org/09/405109/1/check/gate-telemetry-dsvm-integration-ceilometer-ubuntu-xenial/b3544ba/console.html#_2016-12-01_06_44_54_763450