### PR TITLE
Py36 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-      - "3.6"
+      - "3.5"
 install:
       - pip install tox 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-      - "3.5"
+      - "3.6"
 install:
       - pip install tox 
 script:
@@ -11,6 +11,7 @@ env:
       - TOXENV=py33
       - TOXENV=py34
       - TOXENV=py35
+      - TOXENV=py36
       - TOXENV=pypy
       - TOXENV=pep8
       - TOXENV=py35-failskip
@@ -18,6 +19,7 @@ env:
       - TOXENV=py35-prefix
       - TOXENV=py27-pytest
       - TOXENV=py35-pytest
+      - TOXENV=py36-pytest
 
 notifications:
       irc: "chat.freenode.net#gabbi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,31 @@
 sudo: false
 language: python
-python:
-      - "3.5"
 install:
       - pip install tox 
 script:
       - tox
-env:
-      - TOXENV=py27
-      - TOXENV=py33
-      - TOXENV=py34
-      - TOXENV=py35
-      - TOXENV=py36
-      - TOXENV=pypy
-      - TOXENV=pep8
-      - TOXENV=py35-failskip
-      - TOXENV=py35-limit
-      - TOXENV=py35-prefix
-      - TOXENV=py27-pytest
-      - TOXENV=py35-pytest
-      - TOXENV=py36-pytest
+matrix:
+    include:
+        - env: TOXENV=py27
+        - env: TOXENV=py33
+        - env: TOXENV=py34
+        - env: TOXENV=pypy
+        - env: TOXENV=pep8
+        - env: TOXENV=py27-pytest
+        - python: 3.5
+          env: TOXENV=py35
+        - python: 3.5
+          env: TOXENV=py35-pytest
+        - python: 3.5
+          env: TOXENV=py35-failskip
+        - python: 3.5
+          env: TOXENV=py35-limit
+        - python: 3.5
+          env: TOXENV=py35-prefix
+        - python: 3.6
+          env: TOXENV=py36
+        - python: 3.6
+          env: TOXENV=py36-pytest
 
 notifications:
       irc: "chat.freenode.net#gabbi"

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ looks like this::
 See the docs_ for more details on the many features and formats for
 setting request headers and bodies and evaluating responses.
 
-Gabbi is tested with Python 2.7, 3.4, 3.5 and pypy.
+Gabbi is tested with Python 2.7, 3.4, 3.5, 3.6 and pypy.
 
 Tests can be run using `unittest`_ style test runners, `pytest`_
 or from the command line with a `gabbi-run`_ script.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifier =
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Topic :: Internet :: WWW/HTTP :: WSGI
     Topic :: Software Development :: Testing
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py33,py34,py35,pypy,pep8,limit,failskip,docs,py35-prefix,py35-limit,py35-failskip,py27-pytest,py35-pytest
+envlist = py27,py33,py34,py35,py36,pypy,pep8,limit,failskip,docs,py35-prefix,py35-limit,py35-failskip,py27-pytest,py35-pytest,py36-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -19,6 +19,9 @@ commands = {posargs}
 commands = py.test gabbi
 
 [testenv:py35-pytest]
+commands = py.test gabbi
+
+[testenv:py36-pytest]
 commands = py.test gabbi
 
 [testenv:py35-prefix]


### PR DESCRIPTION
Add support for py36 to travis and tox, validating that gabbi supports python 3.6.