### PR TITLE
Add optional testing of current gabbi with current gnocchi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - env: TOXENV=pypy
         - env: TOXENV=pep8
         - env: TOXENV=py27-pytest
+        - env: TOXENV=gnocchi
         - python: 3.5
           env: TOXENV=py35
         - python: 3.5
@@ -26,6 +27,8 @@ matrix:
           env: TOXENV=py36
         - python: 3.6
           env: TOXENV=py36-pytest
+    allow_failures:
+        - env: TOXENV=gnocchi
 
 notifications:
       irc: "chat.freenode.net#gabbi"

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,15 @@ commands = python setup.py testr --coverage --testr-args="{posargs}"
 [testenv:pytest-cov]
 commands = py.test --cov=gabbi gabbi/tests --cov-config .coveragerc --cov-report html
 
+[testenv:gnocchi]
+basepython = python2.7
+deps = -egit+http://git.openstack.org/openstack/gnocchi#egg=gnocchi
+       tox
+changedir = {envdir}/src/gnocchi
+commands = tox -e py27-gabbi --notest  # ensure a virtualenv is built
+           {envdir}/src/gnocchi/.tox/py27-gabbi/bin/pip install -U {toxinidir}  # install gabbi
+           tox -e py27-gabbi
+
 [testenv:docs]
 commands =
     rm -rf doc/build


### PR DESCRIPTION
Gnocchi is a big consumer of gabbi so it is useful to run the gabbi
tests in gnocchi against the new gabbi to raise red flags where there
are issues.