### PR TITLE
add application/xml.* as non-binary

### DIFF
--- a/gabbi/tests/test_utils.py
+++ b/gabbi/tests/test_utils.py
@@ -32,6 +32,7 @@ class BinaryTypesTest(unittest.TestCase):
         'application/javascript',
         'application/json',
         'application/json-home',
+        'application/xml',
     ]
 
     def test_not_binary(self):

--- a/gabbi/utils.py
+++ b/gabbi/utils.py
@@ -109,7 +109,8 @@ def not_binary(content_type):
             content_type.endswith('+xml') or
             content_type.endswith('+json') or
             content_type == 'application/javascript' or
-            content_type.startswith('application/json'))
+            content_type.startswith('application/json') or
+            content_type.startswith('application/xml'))
 
 
 def parse_content_type(content_type, default_charset='utf-8'):


### PR DESCRIPTION
We're testing an S3 compatible API, and verbose=all doesn't show our errors, as gabbi thinks `application/xml` is a binary mime type.

I've used `startswith` so that a mime type like `application/xml-dtd` (Document Type Definition) also gets tagged non-binary.