### PR TITLE
Adjust runner to track test suite failures

### DIFF
--- a/gabbi/reporter.py
+++ b/gabbi/reporter.py
@@ -80,7 +80,8 @@ class ConciseTestResult(TextTestResult):
             self.stream.writeln('\t[unexpected success]')
 
     def getDescription(self, test):
-        name = test.test_data['name']
+        # Chop the test method (test_request) off the test.id().
+        name = test.id().rsplit('.', 1)[0]
         desc = test.test_data.get('desc', None)
         return ': '.join((name, desc)) if desc else name
 

--- a/gabbi/reporter.py
+++ b/gabbi/reporter.py
@@ -80,7 +80,7 @@ class ConciseTestResult(TextTestResult):
             self.stream.writeln('\t[unexpected success]')
 
     def getDescription(self, test):
-        # Chop the test method (test_request) off the test.id().
+        # Chop the test method ('test_request') off the test.id().
         name = test.id().rsplit('.', 1)[0]
         desc = test.test_data.get('desc', None)
         return ': '.join((name, desc)) if desc else name


### PR DESCRIPTION
Change the reporter used by gabbi-run so that it provides a more
complete test name in its output, using the id() of the test. This
will include the name of the yaml file.

Also track failures per input file and provide a summary of which
files contained failures (if any) at the end.

Both of these changes were done in the simplest way possible so
there is probably considerably room for improvement now that the
concept has been proven.

Fixes #181