### PR TITLE
Convert file content to text_type

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -474,7 +474,7 @@ class HTTPTestCase(testtools.TestCase):
                 info = self._load_data_file(data.replace('<@', '', 1))
                 if utils.not_binary(content_type):
                     try:
-                        info = str(info, 'UTF-8')
+                        info = six.text_type(info, 'UTF-8')
                     except TypeError:
                         info = info.encode('UTF-8')
                     data = info


### PR DESCRIPTION
In [fixing a bug in gabbi-tools](https://github.com/hogarthww/gabbi-tools/pull/1), I think I found a bug in Gabbi.

It's using `str` which has different meanings on Python2 and Python3. This was failing on Python2 because it's trying to convert binary data to binary data.

Please have a look at that gabbi-tools PR to see if I can add a test to gabbi test, that would catch this bug. My thought is that `_test_data_to_string` is an internal function, and therefore, do we need to find a public function to replicate the bug, and write a test against that?