### PR TITLE
Allow substitutions in count and delay

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -442,8 +442,9 @@ class HTTPTestCase(testtools.TestCase):
             body = body.encode('UTF-8')
 
         if test['poll']:
-            count = test['poll'].get('count', 1)
-            delay = test['poll'].get('delay', 1)
+            count = int(float(self.replace_template(
+                test['poll'].get('count', 1))))
+            delay = float(self.replace_template(test['poll'].get('delay', 1)))
             failure = None
             while count:
                 try:

--- a/gabbi/tests/gabbits_intercept/poll.yaml
+++ b/gabbi/tests/gabbits_intercept/poll.yaml
@@ -26,7 +26,7 @@ tests:
 
     # Confirm that $LOCATION and $RESPONSE behave in poll.
     - name: create a thing
-      url: /poller?count=2&x=1&y=2
+      url: /poller?count=2&x=1&y=2&z=3.4
       method: POST
       request_headers:
           content-type: application/json
@@ -34,15 +34,16 @@ tests:
           count: 3
           delay: .01
       response_json_paths:
-          $.x[0]: '1'
-          $.y[0]: '2'
+          $.x[0]: "1"
+          $.y[0]: "2"
+          $.z[0]: "3.4"
 
 
     - name: loop location
       url: $LOCATION
       verbose: True
       poll:
-          count: 3
+          count: $RESPONSE['$.z[0]']
           delay: .01
       response_json_paths:
           $.x[0]: $RESPONSE['$.x[0]']


### PR DESCRIPTION
Since we know that count must always be an int and delay can be
either an int or float, the yaml data is passed through
replace_template and then cast to int or float explicitly.

This is different previous solution which tries to rely on the
casting happening in replace_template. With the new coerce style of
numbers-in-data handling being developed in #206 that strategy won't
work. In any case, this way is more contained and explicit.

Fixes #150