### PR TITLE
Enforce type of response/content-handler test data

### DIFF
--- a/gabbi/handlers/base.py
+++ b/gabbi/handlers/base.py
@@ -13,6 +13,9 @@
 """Base classes for response and content handlers."""
 
 
+from gabbi.exception import GabbiFormatError
+
+
 class ResponseHandler(object):
     """Add functionality for making assertions about an HTTP response.
 
@@ -38,6 +41,11 @@ class ResponseHandler(object):
     def __call__(self, test):
         if test.test_data[self._key]:
             self.preprocess(test)
+            if type(self.test_key_value) != type(test.test_data[self._key]):
+                raise GabbiFormatError(
+                    "%s in '%s' has incorrect type, must be %s"
+                    % (self._key, test.test_data['name'],
+                       type(self.test_key_value)))
             for item in test.test_data[self._key]:
                 try:
                     value = test.test_data[self._key][item]

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -17,6 +17,7 @@ import json
 import unittest
 
 from gabbi import case
+from gabbi.exception import GabbiFormatError
 from gabbi.handlers import core
 from gabbi.handlers import jsonhandler
 from gabbi import suitemaker
@@ -104,6 +105,19 @@ class HandlersTest(unittest.TestCase):
         # Check the pprint of the json
         self.assertIn('      "location": "house"', msg)
 
+    def test_response_string_list_type(self):
+        handler = core.StringResponseHandler()
+        self.test.test_data = {
+            'name': 'omega test',
+            'response_strings': 'omega'
+        }
+        self.test.output = 'omega\n'
+        with self.assertRaises(GabbiFormatError) as exc:
+            self._assert_handler(handler)
+            self.assertIn('has incorrect type', str(exc))
+            self.assertIn("response_strings in 'omega test'",
+                          str(exc))
+
     def test_response_json_paths(self):
         handler = jsonhandler.JSONHandler()
         self.test.content_type = "application/json"
@@ -177,6 +191,19 @@ class HandlersTest(unittest.TestCase):
                          'location': 'house'}]
         }
         self._assert_handler(handler)
+
+    def test_response_json_paths_dict_type(self):
+        handler = jsonhandler.JSONHandler()
+        self.test.test_data = {
+            'name': 'omega test',
+            'response_json_paths': ['alpha', 'beta']
+        }
+        self.test.output = 'omega\n'
+        with self.assertRaises(GabbiFormatError) as exc:
+            self._assert_handler(handler)
+            self.assertIn('has incorrect type', str(exc))
+            self.assertIn("response_json_paths in 'omega test'",
+                          str(exc))
 
     def test_response_headers(self):
         handler = core.HeadersResponseHandler()


### PR DESCRIPTION
Each of the response and content handlers has an expected type that
the test data should be in (in the YAML file). For example
response_strings should be a list. These changes add some
enforcement of those types, without which it is possible to (rarely)
get false positives when using a str value where a list value is
expected and the assertions using that value use 'in'.

Fixes #209