### PR TITLE
Add optional `test` param for custom content handlers

### DIFF
--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -107,8 +107,11 @@ handler might accept ``application/x-www-form-urlencoded`` and
 
 If ``accepts`` is defined two additional static methods should be defined:
 
-* ``dumps``: Turn structured Python data from the ``data`` key in a
-  test into a string or byte stream.
+* ``dumps``: Turn structured Python data from the ``data`` key in a test into a
+  string or byte stream. The optional ``test`` param allows you to access the
+  current test case which may help with manipulations for custom content
+  handlers, e.g. multipart/form-data needs to add a `boundary` to the
+  Content-Type header in order to mark the appropriate sections of the body.
 * ``loads``: Turn a string or byte stream in a response into a Python data
   structure. Gabbi will put this data on the ``response_data``
   attribute on the test, where it can be used in the evaluations

--- a/docs/source/handlers.rst
+++ b/docs/source/handlers.rst
@@ -110,8 +110,9 @@ If ``accepts`` is defined two additional static methods should be defined:
 * ``dumps``: Turn structured Python data from the ``data`` key in a test into a
   string or byte stream. The optional ``test`` param allows you to access the
   current test case which may help with manipulations for custom content
-  handlers, e.g. multipart/form-data needs to add a `boundary` to the
-  Content-Type header in order to mark the appropriate sections of the body.
+  handlers, e.g. ``multipart/form-data`` needs to add a ``boundary`` to the
+  ``Content-Type`` header in order to mark the appropriate sections of the
+  body.
 * ``loads``: Turn a string or byte stream in a response into a Python data
   structure. Gabbi will put this data on the ``response_data``
   attribute on the test, where it can be used in the evaluations

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -545,10 +545,6 @@ class HTTPTestCase(testtools.TestCase):
                 if dumper_class:
                     full_response = dumper_class.dumps(self.response_data,
                                                        pretty=True, test=self)
-                    # Sometimes, a given content handler may not hand back a
-                    # string for transmission, so we should be careful.
-                    if not isinstance(full_response, six.string_types):
-                        full_response = str(full_response)
                 else:
                     full_response = self.output
             else:

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -485,7 +485,7 @@ class HTTPTestCase(testtools.TestCase):
         else:
             dumper_class = self.get_content_handler(content_type)
             if dumper_class:
-                data = dumper_class.dumps(data)
+                data = dumper_class.dumps(data, test=self)
             else:
                 raise ValueError(
                     'unable to process data to %s' % content_type)
@@ -544,7 +544,11 @@ class HTTPTestCase(testtools.TestCase):
                 dumper_class = self.get_content_handler(self.content_type)
                 if dumper_class:
                     full_response = dumper_class.dumps(self.response_data,
-                                                       pretty=True)
+                                                       pretty=True, test=self)
+                    # Sometimes, a given content handler may not hand back a
+                    # string for transmission, so we should be careful.
+                    if not isinstance(full_response, six.string_types):
+                        full_response = str(full_response)
                 else:
                     full_response = self.output
             else:

--- a/gabbi/handlers/base.py
+++ b/gabbi/handlers/base.py
@@ -100,7 +100,7 @@ class ContentHandler(ResponseHandler):
         return path
 
     @staticmethod
-    def dumps(data, pretty=False):
+    def dumps(data, pretty=False, test=None):
         """Return structured data as a string.
 
         If pretty is true, prettify.

--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -44,7 +44,7 @@ class JSONHandler(base.ContentHandler):
         return str(cls.extract_json_path_value(response_data, match))
 
     @staticmethod
-    def dumps(data, pretty=False):
+    def dumps(data, pretty=False, test=None):
         if pretty:
             return json.dumps(data, indent=2, separators=(',', ': '))
         else:


### PR DESCRIPTION
This resolve #211.

`multipart/form-data` transmission requires modifying the `Content-Type` header with a `boundary` section identifier, and as such a custom content handler would not have previously had access to the running test case it was working on. This should hopefully be useful for other custom content handlers in the future.

Please let me know if the documentation could be better worded or if the check for the return of `dumps` in `assert_in_or_print_output` seems unnecessary (lines 547-551 of commit d71a477).