### PR TITLE
Manage numerals more effectively in replacers

### DIFF
--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -41,7 +41,7 @@ class JSONHandler(base.ContentHandler):
 
     @classmethod
     def replacer(cls, response_data, match):
-        return str(cls.extract_json_path_value(response_data, match))
+        return cls.extract_json_path_value(response_data, match)
 
     @staticmethod
     def dumps(data, pretty=False, test=None):

--- a/gabbi/tests/gabbits_intercept/coerce.yaml
+++ b/gabbi/tests/gabbits_intercept/coerce.yaml
@@ -190,3 +190,12 @@ tests:
           - $HISTORY['check posted data'].$RESPONSE['$.h.key.less_key[1]']
           - $HISTORY['check posted data'].$RESPONSE['$.h.key.less_key[2]']
         more_key: $HISTORY['check posted data'].$RESPONSE['$.h.key.more_key']
+
+- name: string internal replace
+  POST: /
+  data:
+    endpoint_resp: /api/0.1/item/$HISTORY['check posted data'].$RESPONSE['$.a']
+    endpoint_var: /api/0.1/item/$ENVIRON['ONE']
+  response_json_paths:
+    endpoint_resp: /api/0.1/item/1
+    endpoint_var: /api/0.1/item/1

--- a/gabbi/tests/gabbits_intercept/coerce.yaml
+++ b/gabbi/tests/gabbits_intercept/coerce.yaml
@@ -1,0 +1,192 @@
+defaults:
+  request_headers:
+      content-type: application/json
+  verbose: True
+
+tests:
+- name: post data
+  POST: /
+  data:
+      one_string: "1"
+      one_int: 1
+      one_float: 1.1
+  response_json_paths:
+      $.one_string: "1"
+      $.one_int: 1
+      $.one_float: 1.1
+  response_strings:
+      - '"one_string": "1"'
+      - '"one_int": 1'
+      - '"one_float": 1.1'
+
+- name: use data
+  desc: data will be coerced because templates in use
+  POST: /
+  data:
+      one_string: !!str "$RESPONSE['$.one_string']"
+      one_int: $RESPONSE['$.one_int']
+      one_float: $RESPONSE['$.one_float']
+  response_json_paths:
+      $.one_string: "1"
+      $.one_int: 1
+      $.one_float: 1.1
+  response_strings:
+      - '"one_string": "1"'
+      - '"one_int": 1'
+      - '"one_float": 1.1'
+
+- name: from environ
+  POST: /
+  data:
+      one_environ: $ENVIRON['ONE']
+  response_json_paths:
+      $.one_environ: 1
+  response_strings:
+      - '"one_environ": 1'
+
+- name: with list
+  POST: /
+  data:
+      - $ENVIRON['ONE']
+      - 2
+      - "3"
+  response_json_paths:
+      $[0]: 1
+      $[1]: 2
+      $[2]: "3"
+  response_strings:
+      - '[1, 2, "3"]'
+
+- name: object with list
+  desc: without recursive handling no coersion
+  POST: /
+  data:
+      collection:
+          - alpha: $ENVIRON['ONE']
+            beta: max
+          - alpha: 2
+            beta: climb
+  response_json_paths:
+      $.collection[0].alpha: 1
+      $.collection[0].beta: max
+      $.collection[1].alpha: 2
+      $.collection[1].beta: climb
+  response_strings:
+      - '"alpha": 1'
+      - '"beta": "max"'
+
+- name: post extra data
+  POST: /
+  data:
+    a: 1
+    b: 1.0
+    c: '[1,2,3]'
+    d: true
+    e: false
+    f:
+      key: val
+    g: null
+    h:
+      key:
+        less_key: [1, true, null]
+        more_key: 1
+  response_json_paths:
+    a: 1
+    b: 1.0
+    c: '[1,2,3]'
+    d: true
+    e: false
+    f:
+      key: val
+    g: null
+    h:
+      key:
+        less_key: [1, true, null]
+        more_key: 1
+
+- name: check posted data
+  POST: /
+  data:
+    a: $RESPONSE['$.a']
+    b: $RESPONSE['$.b']
+    c: $RESPONSE['$.c']
+    d: $RESPONSE['$.d']
+    e: $RESPONSE['$.e']
+    f: $RESPONSE['$.f']
+    g: $RESPONSE['$.g']
+    h: $RESPONSE['$.h']
+  response_json_paths:
+    a: 1
+    b: 1.0
+    c: '[1,2,3]'
+    d: true
+    e: false
+    f:
+      key: val
+    g: null
+    h:
+      key:
+        less_key: [1, true, null]
+        more_key: 1
+
+- name: Post again and check the results
+  POST: /
+  data:
+    a: $HISTORY['post extra data'].$RESPONSE['$.a']
+    b: $HISTORY['post extra data'].$RESPONSE['$.b']
+    c: $HISTORY['post extra data'].$RESPONSE['$.c']
+    d: $HISTORY['post extra data'].$RESPONSE['$.d']
+    e: $HISTORY['post extra data'].$RESPONSE['$.e']
+    f: $HISTORY['post extra data'].$RESPONSE['$.f']
+    g: $HISTORY['post extra data'].$RESPONSE['$.g']
+    h: $HISTORY['post extra data'].$RESPONSE['$.h']
+  response_json_paths:
+    a: $ENVIRON['ONE']
+    b: $ENVIRON['DECIMAL']
+    c: $ENVIRON['ARRAY_STRING']
+    d: $ENVIRON['TRUE']
+    e: $ENVIRON['FALSE']
+    f:
+      key: $ENVIRON['STRING']
+    g: $ENVIRON['NULL']
+    h:
+      key:
+        less_key:
+          - $ENVIRON['ONE']
+          - $ENVIRON['TRUE']
+          - $ENVIRON['NULL']
+        more_key: $ENVIRON['ONE']
+
+- name: Post again and check the results (reversed)
+  POST: /
+  data:
+    a: $ENVIRON['ONE']
+    b: $ENVIRON['DECIMAL']
+    c: $ENVIRON['ARRAY_STRING']
+    d: $ENVIRON['TRUE']
+    e: $ENVIRON['FALSE']
+    f:
+      key: $ENVIRON['STRING']
+    g: $ENVIRON['NULL']
+    h:
+      key:
+        less_key:
+          - $ENVIRON['ONE']
+          - $ENVIRON['TRUE']
+          - $ENVIRON['NULL']
+        more_key: $ENVIRON['ONE']
+  response_json_paths:
+    a: $HISTORY['check posted data'].$RESPONSE['$.a']
+    b: $HISTORY['check posted data'].$RESPONSE['$.b']
+    c: $HISTORY['check posted data'].$RESPONSE['$.c']
+    d: $HISTORY['check posted data'].$RESPONSE['$.d']
+    e: $HISTORY['check posted data'].$RESPONSE['$.e']
+    f: $HISTORY['check posted data'].$RESPONSE['$.f']
+    g: $HISTORY['check posted data'].$RESPONSE['$.g']
+    h:
+      key:
+        less_key:
+          - $HISTORY['check posted data'].$RESPONSE['$.h.key.less_key[0]']
+          - $HISTORY['check posted data'].$RESPONSE['$.h.key.less_key[1]']
+          - $HISTORY['check posted data'].$RESPONSE['$.h.key.less_key[2]']
+        more_key: $HISTORY['check posted data'].$RESPONSE['$.h.key.more_key']

--- a/gabbi/tests/test_gabbits_pytest.py
+++ b/gabbi/tests/test_gabbits_pytest.py
@@ -24,12 +24,13 @@ from gabbi import driver
 from gabbi.driver import test_pytest  # noqa
 from gabbi.tests import simple_wsgi
 from gabbi.tests import test_intercept
+from gabbi.tests import util
 
 TESTS_DIR = 'gabbits_intercept'
 
 
 def pytest_generate_tests(metafunc):
-    os.environ['GABBI_TEST_URL'] = 'takingnames'
+    util.set_test_environ()
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
     driver.py_test_generator(
         test_dir, intercept=simple_wsgi.SimpleWsgi,

--- a/gabbi/tests/test_intercept.py
+++ b/gabbi/tests/test_intercept.py
@@ -23,6 +23,7 @@ from gabbi import driver
 from gabbi import fixture
 from gabbi.handlers import base
 from gabbi.tests import simple_wsgi
+from gabbi.tests import util
 
 
 TESTS_DIR = 'gabbits_intercept'
@@ -64,7 +65,8 @@ SkipAllFixture = fixture.SkipAllFixture
 def load_tests(loader, tests, pattern):
     """Provide a TestSuite to the discovery process."""
     # Set and environment variable for one of the tests.
-    os.environ['GABBI_TEST_URL'] = 'takingnames'
+    util.set_test_environ()
+
     prefix = os.environ.get('GABBI_PREFIX')
     test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
     return driver.build_tests(test_dir, loader, host=None,

--- a/gabbi/tests/test_replacers.py
+++ b/gabbi/tests/test_replacers.py
@@ -37,8 +37,17 @@ class EnvironReplaceTest(unittest.TestCase):
         os.environ['moo'] = "False"
         self.assertEqual(False, http_case._environ_replace(message))
 
+        os.environ['moo'] = "true"
+        self.assertEqual(True, http_case._environ_replace(message))
+
+        os.environ['moo'] = "faLse"
+        self.assertEqual(False, http_case._environ_replace(message))
+
+        os.environ['moo'] = "null"
+        self.assertEqual(None, http_case._environ_replace(message))
+
         os.environ['moo'] = "1"
-        self.assertEqual("1", http_case._environ_replace(message))
+        self.assertEqual(1, http_case._environ_replace(message))
 
         os.environ['moo'] = "cow"
         self.assertEqual("cow", http_case._environ_replace(message))

--- a/gabbi/tests/util.py
+++ b/gabbi/tests/util.py
@@ -1,0 +1,29 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Utility methods shared by some tests."""
+
+import os
+
+
+def set_test_environ():
+    """Set some environment variables used in tests."""
+    os.environ['GABBI_TEST_URL'] = 'takingnames'
+
+    # Setup environment variables for `coerce.yaml`
+    os.environ['ONE'] = '1'
+    os.environ['DECIMAL'] = '1.0'
+    os.environ['ARRAY_STRING'] = '[1,2,3]'
+    os.environ['TRUE'] = 'true'
+    os.environ['FALSE'] = 'false'
+    os.environ['STRING'] = 'val'
+    os.environ['NULL'] = 'null'


### PR DESCRIPTION
Change the handling in response_replacer and jsonhandler.replace so
that numerals are preserved. The primary change here is that replace
does not always return a str: it returns the found data. The
remaining changes cascade from this fix.

* If the 'message' being replaced is fully the regex, don't do
  regex-based replacement (which requires a string). Instead return
  the new value.

* Do template replacing on test data _before_ dumping it to a string.
  This allows the small 'message' replacements described in the previous
  point.

* Assure we can recurse through lists, not just dicts, when
  replacing in data structures.

In the pull request at #206 there is a different mode of coercing
and preserving data types operates by adding a coerce method to
content handlers. While inspecting this it seemed like it might be
too complex, so this alternate option has been explored. This might
work, or perhaps a hybrid of the two.

The coerce.yaml file from #206 was copied here and adapted to fit
the different assumptions that are made in this change. Some of the
assumptions in 206 don't map well to YAML handling of literal data
formats.