### PR TITLE
Read full json

### DIFF
--- a/docs/source/jsonpath.rst
+++ b/docs/source/jsonpath.rst
@@ -64,8 +64,23 @@ lead to difficult to read tests and it also indicates that your
 gabbi tests are being used to test your serializers and data models,
 not just your API interactions.
 
+It is also possible to read raw JSON from disk for either all or
+some of a JSON response::
+
+    response_json_paths:
+        $: @<data.json
+
+or::
+
+    response_json_paths:
+        $.pets: <@pets.json
+        $.pets[0]: <@cat.json
+
+Examples like this can be found in one of gabbi's `own tests`_.
+
 There are more JSONPath examples in :doc:`example` and in the
 `jsonpath_rw`_ and `jsonpath_rw_ext`_ documentation.
 
 .. _jsonpath_rw: http://jsonpath-rw.readthedocs.io/en/latest/
 .. _jsonpath_rw_ext: https://python-jsonpath-rw-ext.readthedocs.io/en/latest/
+.. _own tests: https://github.com/cdent/gabbi/blob/master/gabbi/tests/gabbits_intercept/data.yaml

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -174,6 +174,10 @@ class HTTPTestCase(testtools.TestCase):
 
         return message
 
+    def load_data_file(self, filename):
+        """Read a file from the current test directory."""
+        return self._load_data_file(filename)
+
     def _assert_response(self):
         """Compare the response with expected data."""
         self._test_status(self.test_data['status'], self.response['status'])
@@ -505,7 +509,7 @@ class HTTPTestCase(testtools.TestCase):
         """
         if isinstance(data, str):
             if data.startswith('<@'):
-                info = self._load_data_file(data.replace('<@', '', 1))
+                info = self.load_data_file(data.replace('<@', '', 1))
                 if utils.not_binary(content_type):
                     data = six.text_type(info, 'UTF-8')
                 else:

--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -14,6 +14,8 @@
 
 import json
 
+import six
+
 from gabbi.handlers import base
 from gabbi import json_parser
 
@@ -86,6 +88,13 @@ class JSONHandler(base.ContentHandler):
         except ValueError:
             raise AssertionError('json path %s cannot match %s' %
                                  (path, test.response_data))
+
+        # read data from disk if the value starts with '<@'
+        if isinstance(value, str) and value.startswith('<@'):
+            info = test.load_data_file(value.replace('<@', '', 1))
+            info = six.text_type(info, 'UTF-8')
+            value = self.loads(info)
+
         expected = test.replace_template(value)
         # If expected is a string, check to see if it is a regex.
         if (hasattr(expected, 'startswith') and expected.startswith('/')

--- a/gabbi/tests/gabbits_intercept/cat.json
+++ b/gabbi/tests/gabbits_intercept/cat.json
@@ -1,0 +1,4 @@
+{
+    "type": "cat",
+    "sound": "meow"
+}

--- a/gabbi/tests/gabbits_intercept/data.yaml
+++ b/gabbi/tests/gabbits_intercept/data.yaml
@@ -58,3 +58,17 @@ tests:
       response_json_paths:
           foo['bár']: 1
           $: <@data.json
+
+    - name: partial json from disk
+      POST: /
+      request_headers:
+          content-type: application/json
+      data:
+          pets:
+              - type: cat
+                sound: meow
+              - type: dog
+                sound: woof
+      response_json_paths:
+          $.pets: <@pets.json
+          $.pets[0]: <@cat.json

--- a/gabbi/tests/gabbits_intercept/data.yaml
+++ b/gabbi/tests/gabbits_intercept/data.yaml
@@ -49,3 +49,12 @@ tests:
       request_headers:
           content-type: text/plain
       data: <@utf8.txt
+
+    - name: json value from disk
+      POST: /
+      request_headers:
+          content-type: application/json
+      data: <@data.json
+      response_json_paths:
+          foo['bár']: 1
+          $: <@data.json

--- a/gabbi/tests/gabbits_intercept/pets.json
+++ b/gabbi/tests/gabbits_intercept/pets.json
@@ -1,0 +1,10 @@
+[
+    {
+        "type": "cat",
+        "sound": "meow"
+    },
+    {
+        "type": "dog",
+        "sound": "woof"
+    }
+]

--- a/gabbi/tests/test_load_data_file.py
+++ b/gabbi/tests/test_load_data_file.py
@@ -35,7 +35,7 @@ class DataFileTest(unittest.TestCase):
 
     def _assert_content_read(self, filepath):
         self.assertEqual(
-            'dummy content', self.http_case._load_data_file(filepath))
+            'dummy content', self.http_case.load_data_file(filepath))
 
     def test_load_file(self, m_open):
         self.http_case.test_directory = '.'
@@ -52,7 +52,7 @@ class DataFileTest(unittest.TestCase):
         filepath = '/top-level.private'
 
         with self.assertRaises(ValueError):
-            self.http_case._load_data_file(filepath)
+            self.http_case.load_data_file(filepath)
         self.assertFalse(m_open.called)
 
     def test_load_file_in_parent_dir(self, m_open):
@@ -60,7 +60,7 @@ class DataFileTest(unittest.TestCase):
         filepath = '../file-in-parent-dir.txt'
 
         with self.assertRaises(ValueError):
-            self.http_case._load_data_file(filepath)
+            self.http_case.load_data_file(filepath)
         self.assertFalse(m_open.called)
 
     def test_load_file_within_test_directory(self, m_open):
@@ -73,5 +73,5 @@ class DataFileTest(unittest.TestCase):
         self.http_case.test_directory = '/a/b/c'
         filepath = '../../b/E/file-in-test-dir.txt'
         with self.assertRaises(ValueError):
-            self.http_case._load_data_file(filepath)
+            self.http_case.load_data_file(filepath)
         self.assertFalse(m_open.called)


### PR DESCRIPTION
The change allows some or all of a JSON value to be read from disk to be used in a json path test. Examples are are in the `data.yaml` test file and in the `jsonpath.rst` file. This will help with test that either need to validate full responses or that have complex responses that need to be verified but are big enough that having them in the yaml file muddies the water.

This feature has been requested by a few different parties. It's not something I originally wanted to do but enough people wanted it and it is easy enough to do that...why fight it?

/cc @FND @jasonamyers @tomviner @justanotherdot 