### PR TITLE
Add a tox target for testing against openstack placement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
           env: TOXENV=py36-pytest
     allow_failures:
         - env: TOXENV=gnocchi
+        - env: TOXENV=placement
 
 notifications:
       irc: "chat.freenode.net#gabbi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         - env: TOXENV=pep8
         - env: TOXENV=py27-pytest
         - env: TOXENV=gnocchi
+        - env: TOXENV=placement
         - python: 3.5
           env: TOXENV=py35
         - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,21 @@ commands = tox -e py27-gabbi --notest  # ensure a virtualenv is built
            {envdir}/src/gnocchi/.tox/py27-gabbi/bin/pip install -U {toxinidir}  # install gabbi
            tox -e py27-gabbi
 
+[testenv:placement]
+basepython = python2.7
+deps = tox
+commands = -mkdir {envdir}/src
+           -rm -r {envdir}/src/*
+           curl -o {envdir}/src/nova.tar.gz https://tarballs.openstack.org/nova/nova-master.tar.gz
+           tar -C {envdir}/src -zxv --strip-components 1 -f nova.tar.gz
+           tox -c {envdir}/src -e functional --notest  # ensure a virtualenv is built
+           {envdir}/src/.tox/functional/bin/pip install -U {toxinidir}  # install gabbi
+           tox -c {envdir}/src -e functional test_placement_api
+whitelist_externals =
+    mkdir
+    curl
+    tar
+
 [testenv:docs]
 commands =
     rm -rf doc/build

--- a/tox.ini
+++ b/tox.ini
@@ -68,8 +68,7 @@ basepython = python2.7
 deps = tox
 commands = -mkdir {envdir}/src
            -rm -r {envdir}/src/*
-           curl -o {envdir}/src/nova.tar.gz https://tarballs.openstack.org/nova/nova-master.tar.gz
-           tar -C {envdir}/src -zxv --strip-components 1 -f nova.tar.gz
+           bash -c "curl https://tarballs.openstack.org/nova/nova-master.tar.gz | tar -C {envdir}/src -zxv --strip-components 1 -f - "
            tox -c {envdir}/src -e functional --notest  # ensure a virtualenv is built
            {envdir}/src/.tox/functional/bin/pip install -U {toxinidir}  # install gabbi
            tox -c {envdir}/src -e functional test_placement_api
@@ -77,6 +76,8 @@ whitelist_externals =
     mkdir
     curl
     tar
+    rm
+    bash
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
The openstack placement service is one of the larger consumers of gabbi.
This change adds a 'placement' tox target get retrieves the latest code
that provides placement and runs the relevant gabbi tests against it.

The target is added to the "allowed to fail" section travis.

This is considerably more complex than the gnocchi target (which does a
similar thing) because this gets the master tarball rather than cloning
the git repo. The clone takes far too long because the curren thost of
the placement service, nova, is very large and very old.