### PR TITLE
use_prior_test directive and flag

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -135,8 +135,8 @@ class HTTPTestCase(testtools.TestCase):
         if self.test_data['skip']:
             self.skipTest(self.test_data['skip'])
 
-        if self.prior and not self.prior.has_run and \
-                self.test_data['use_prior_test']:
+        if (self.prior and not self.prior.has_run and 
+                self.test_data['use_prior_test']):
             # Use a different result so we don't count this test
             # in the results.
             self.prior.run(result.TestResult())

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -135,7 +135,7 @@ class HTTPTestCase(testtools.TestCase):
         if self.test_data['skip']:
             self.skipTest(self.test_data['skip'])
 
-        if (self.prior and not self.prior.has_run and 
+        if (self.prior and not self.prior.has_run and
                 self.test_data['use_prior_test']):
             # Use a different result so we don't count this test
             # in the results.

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -69,6 +69,7 @@ BASE_TEST = {
     'xfail': False,
     'skip': '',
     'poll': {},
+    'use_prior_test': True,
 }
 
 
@@ -134,7 +135,8 @@ class HTTPTestCase(testtools.TestCase):
         if self.test_data['skip']:
             self.skipTest(self.test_data['skip'])
 
-        if self.prior and not self.prior.has_run:
+        if self.prior and not self.prior.has_run and \
+                self.test_data['use_prior_test']:
             # Use a different result so we don't count this test
             # in the results.
             self.prior.run(result.TestResult())

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -42,10 +42,11 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
                 test_loader_name=None, fixture_module=None,
                 response_handlers=None, content_handlers=None,
                 prefix='', require_ssl=False, url=None,
-                inner_fixtures=None, verbose=False):
+                inner_fixtures=None, verbose=False,
+                use_prior_test=True):
     """Read YAML files from a directory to create tests.
 
-    Each YAML file represents an ordered sequence of HTTP requests.
+    Each YAML file represents a list of HTTP requests.
 
     :param path: The directory where yaml files are located.
     :param loader: The TestLoader.
@@ -66,6 +67,8 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
                            individual test request.
     :param verbose: If ``True`` or ``'all'``, make tests verbose by default
                     ``'headers'`` and ``'body'`` are also accepted.
+    :param use_prior_test: If ``True``, uses prior test to create ordered
+                           sequence of tests
     :type inner_fixtures: List of fixtures.Fixture classes.
     :rtype: TestSuite containing multiple TestSuites (one for each YAML file).
     """
@@ -125,6 +128,12 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
                 suite_dict['defaults']['verbose'] = verbose
             else:
                 suite_dict['defaults'] = {'verbose': verbose}
+
+        if not use_prior_test:
+            if 'defaults' in suite_dict:
+                suite_dict['defaults']['use_prior_test'] = use_prior_test
+            else:
+                suite_dict['defaults'] = {'use_prior_test': use_prior_test}
 
         file_suite = suitemaker.test_suite_from_dict(
             loader, test_base_name, suite_dict, path, host, port,

--- a/gabbi/tests/test_driver.py
+++ b/gabbi/tests/test_driver.py
@@ -28,13 +28,13 @@ class DriverTest(unittest.TestCase):
         self.loader = unittest.defaultTestLoader
         self.test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
 
-    def test_driver_loads_two_tests(self):
+    def test_driver_loads_three_tests(self):
         suite = driver.build_tests(self.test_dir, self.loader,
                                    host='localhost', port=8001)
         self.assertEqual(1, len(suite._tests),
                          'top level suite contains one suite')
-        self.assertEqual(2, len(suite._tests[0]._tests),
-                         'contained suite contains two tests')
+        self.assertEqual(3, len(suite._tests[0]._tests),
+                         'contained suite contains three tests')
         the_one_test = suite._tests[0]._tests[0]
         self.assertEqual('test_driver_sample_one',
                          the_one_test.__class__.__name__,
@@ -97,3 +97,22 @@ class DriverTest(unittest.TestCase):
         first_test = suite._tests[0]._tests[0]
         full_url = first_test._parse_url(first_test.test_data['url'])
         self.assertEqual('https://example.com:1024/theend/', full_url)
+
+    def test_build_url_use_prior_test(self):
+        suite = driver.build_tests(self.test_dir, self.loader,
+                                   host='localhost',
+                                   use_prior_test=True)
+        for test in suite._tests[0]._tests:
+            if test.test_data['name'] != 'use_prior_false':
+                expected_use_prior = True
+            else:
+                expected_use_prior = False
+
+            self.assertEqual(expected_use_prior,
+                             test.test_data['use_prior_test'])
+
+        suite = driver.build_tests(self.test_dir, self.loader,
+                                   host='localhost',
+                                   use_prior_test=False)
+        for test in suite._tests[0]._tests:
+            self.assertEqual(False, test.test_data['use_prior_test'])

--- a/gabbi/tests/test_gabbits/sample.yaml
+++ b/gabbi/tests/test_gabbits/sample.yaml
@@ -1,6 +1,11 @@
+defaults:
+  use_prior_test: True
 
 tests:
     - name: one
       url: /
     - name: two
       url: http://example.com/moo
+    - name: use_prior_false
+      url: http://example.com/foo
+      use_prior_test: False

--- a/gabbi/tests/test_use_prior_test.py
+++ b/gabbi/tests/test_use_prior_test.py
@@ -1,0 +1,39 @@
+from collections import OrderedDict
+import copy
+import unittest
+from six.moves import mock
+
+from gabbi import case
+
+
+class UsePriorTest(unittest.TestCase):
+
+    @staticmethod
+    def make_test_case(use_prior_test=None):
+        http_case = case.HTTPTestCase('test_request')
+        http_case.test_data = copy.copy(case.BASE_TEST)
+        if use_prior_test is not None:
+            http_case.test_data['use_prior_test'] = use_prior_test
+        return http_case
+
+    @mock.patch('gabbi.case.HTTPTestCase._run_test')
+    def test_use_prior_set(self, m_run_test):
+        http_case = self.make_test_case(True)
+        http_case.has_run = False
+        http_case.prior = self.make_test_case(True)
+        http_case.prior.run = mock.MagicMock(unsafe=True)
+        http_case.prior.has_run = False
+
+        http_case.test_request()
+        http_case.prior.run.assert_called_once()
+
+    @mock.patch('gabbi.case.HTTPTestCase._run_test')
+    def test_use_prior_not_set(self, m_run_test):
+        http_case = self.make_test_case(False)
+        http_case.has_run = False
+        http_case.prior = self.make_test_case(True)
+        http_case.prior.run = mock.MagicMock(unsafe=True)
+        http_case.prior.has_run = False
+
+        http_case.test_request()
+        http_case.prior.run.assert_not_called()

--- a/gabbi/tests/test_use_prior_test.py
+++ b/gabbi/tests/test_use_prior_test.py
@@ -1,4 +1,18 @@
-from collections import OrderedDict
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Test use_prior_test directive.
+"""
+
 import copy
 import unittest
 from six.moves import mock
@@ -17,7 +31,7 @@ class UsePriorTest(unittest.TestCase):
         return http_case
 
     @mock.patch('gabbi.case.HTTPTestCase._run_test')
-    def test_use_prior_set(self, m_run_test):
+    def test_use_prior_true(self, m_run_test):
         http_case = self.make_test_case(True)
         http_case.has_run = False
         http_case.prior = self.make_test_case(True)
@@ -28,7 +42,7 @@ class UsePriorTest(unittest.TestCase):
         http_case.prior.run.assert_called_once()
 
     @mock.patch('gabbi.case.HTTPTestCase._run_test')
-    def test_use_prior_not_set(self, m_run_test):
+    def test_use_prior_false(self, m_run_test):
         http_case = self.make_test_case(False)
         http_case.has_run = False
         http_case.prior = self.make_test_case(True)
@@ -37,3 +51,14 @@ class UsePriorTest(unittest.TestCase):
 
         http_case.test_request()
         http_case.prior.run.assert_not_called()
+
+    @mock.patch('gabbi.case.HTTPTestCase._run_test')
+    def test_use_prior_default_true(self, m_run_test):
+        http_case = self.make_test_case()
+        http_case.has_run = False
+        http_case.prior = self.make_test_case(True)
+        http_case.prior.run = mock.MagicMock(unsafe=True)
+        http_case.prior.has_run = False
+
+        http_case.test_request()
+        http_case.prior.run.assert_called_once()

--- a/gabbi/tests/test_use_prior_test.py
+++ b/gabbi/tests/test_use_prior_test.py
@@ -14,8 +14,8 @@
 """
 
 import copy
-import unittest
 from six.moves import mock
+import unittest
 
 from gabbi import case
 


### PR DESCRIPTION
* Added use_prior_test flag to build_tests.  Defaults to True.
* Added use_prior_test directive in YAML file.
  - If not set in the YAML file, it will default to the value set by
    build_tests.
  - If it is set in the YAML file, its value will override the
    use_prior_test value set by build_tests.
* When executing a test, only run prior test if use_prior_test is True.
* Added tests verifying build_tests and HTTPTestCase test_request
  behavior with use_prior_test.