### PR TITLE
Various regular expression fixes

### DIFF
--- a/docs/source/example.yaml
+++ b/docs/source/example.yaml
@@ -62,10 +62,11 @@ tests:
       status: 302
 
 # When evaluating response headers it is possible to use a regular
-# expression to not have to test the whole value.
+# expression to not have to test the whole value. Regular expressions match
+# anywhere in the output, not just at the beginning.
 
       response_headers:
-          location: /https/
+          location: /^https/
 
 # By default redirects will not be followed. This can be changed.
 

--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -144,7 +144,8 @@ Response Expectations
                                    representing expected response header
                                    names and values. If a header's value
                                    is wrapped in ``/.../``, it will be
-                                   treated as a regular expression.
+                                   treated as a regular expression to
+                                   search for in the response header.
 
    ``response_forbidden_headers``  A list of headers which must `not`
                                    be present.
@@ -161,7 +162,7 @@ Response Expectations
 
                                    If the value is wrapped in ``/.../``
                                    the result of the JSONPath query
-                                   will be compared against the
+                                   will be searched for the
                                    value as a regular expression.
 
    ``poll``                        A dictionary of two keys:

--- a/gabbi/handlers/core.py
+++ b/gabbi/handlers/core.py
@@ -53,9 +53,14 @@ class HeadersResponseHandler(base.ResponseHandler):
 
     def action(self, test, header, value=None):
         header = header.lower()  # case-insensitive comparison
-
         response = test.response
-        header_value = test.replace_template(str(value))
+
+        header_value = str(value)
+        is_regex = (header_value.startswith('/') and
+                    header_value.endswith('/') and
+                    len(header_value) > 1)
+        header_value = test.replace_template(header_value,
+                                             escape_regex=is_regex)
 
         try:
             response_value = str(response[header])
@@ -64,8 +69,7 @@ class HeadersResponseHandler(base.ResponseHandler):
                 "'%s' header not present in response: %s" % (
                     header, response.keys()))
 
-        if (header_value.startswith('/') and header_value.endswith('/')
-                and len(header_value) > 1):
+        if is_regex:
             header_value = header_value[1:-1]
             test.assertRegex(
                 response_value, header_value,

--- a/gabbi/handlers/core.py
+++ b/gabbi/handlers/core.py
@@ -64,8 +64,9 @@ class HeadersResponseHandler(base.ResponseHandler):
                 "'%s' header not present in response: %s" % (
                     header, response.keys()))
 
-        if header_value.startswith('/') and header_value.endswith('/'):
-            header_value = header_value.strip('/').rstrip('/')
+        if (header_value.startswith('/') and header_value.endswith('/')
+                and len(header_value) > 1):
+            header_value = header_value[1:-1]
             test.assertRegex(
                 response_value, header_value,
                 'Expect header %s to match /%s/, got %s' %

--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -94,9 +94,11 @@ class JSONHandler(base.ContentHandler):
 
         expected = test.replace_template(value)
         # If expected is a string, check to see if it is a regex.
-        if (hasattr(expected, 'startswith') and expected.startswith('/')
-                and expected.endswith('/')):
-            expected = expected.strip('/').rstrip('/')
+        if (isinstance(expected, six.string_types)
+                and expected.startswith('/')
+                and expected.endswith('/')
+                and len(expected) > 1):
+            expected = expected[1:-1]
             # match may be a number so stringify
             match = six.text_type(match)
             test.assertRegexpMatches(

--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -98,7 +98,7 @@ class JSONHandler(base.ContentHandler):
                 and expected.endswith('/')):
             expected = expected.strip('/').rstrip('/')
             # match may be a number so stringify
-            match = str(match)
+            match = six.text_type(match)
             test.assertRegexpMatches(
                 match, expected,
                 'Expect jsonpath %s to match /%s/, got %s' %

--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -92,12 +92,13 @@ class JSONHandler(base.ContentHandler):
             info = six.text_type(info, 'UTF-8')
             value = self.loads(info)
 
-        expected = test.replace_template(value)
         # If expected is a string, check to see if it is a regex.
-        if (isinstance(expected, six.string_types)
-                and expected.startswith('/')
-                and expected.endswith('/')
-                and len(expected) > 1):
+        is_regex = (isinstance(value, six.string_types) and
+                    value.startswith('/') and
+                    value.endswith('/') and
+                    len(value) > 1)
+        expected = test.replace_template(value, escape_regex=is_regex)
+        if is_regex:
             expected = expected[1:-1]
             # match may be a number so stringify
             match = six.text_type(match)

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -178,6 +178,29 @@ class HandlersTest(unittest.TestCase):
         }
         self._assert_handler(handler)
 
+    def test_response_json_paths_regex_path_match(self):
+        handler = jsonhandler.JSONHandler()
+        self.test.content_type = "application/json"
+        self.test.test_data = {'response_json_paths': {
+            '$.pathtest': '//bar//',
+        }}
+        self.test.response_data = {
+            'pathtest': '/foo/bar/baz'
+        }
+        self._assert_handler(handler)
+
+    def test_response_json_paths_regex_path_nomatch(self):
+        handler = jsonhandler.JSONHandler()
+        self.test.content_type = "application/json"
+        self.test.test_data = {'response_json_paths': {
+            '$.pathtest': '//bar//',
+        }}
+        self.test.response_data = {
+            'pathtest': '/foo/foobar/baz'
+        }
+        with self.assertRaises(AssertionError):
+            self._assert_handler(handler)
+
     def test_response_json_paths_regex_number(self):
         handler = jsonhandler.JSONHandler()
         self.test.content_type = "application/json"
@@ -226,6 +249,40 @@ class HandlersTest(unittest.TestCase):
         }}
         self.test.response = {'content-type': 'text/plain; charset=UTF-8'}
         self._assert_handler(handler)
+
+    def test_response_headers_noregex_path_match(self):
+        handler = core.HeadersResponseHandler()
+        self.test.test_data = {'response_headers': {
+            'location': '/',
+        }}
+        self.test.response = {'location': '/'}
+        self._assert_handler(handler)
+
+    def test_response_headers_noregex_path_nomatch(self):
+        handler = core.HeadersResponseHandler()
+        self.test.test_data = {'response_headers': {
+            'location': '/',
+        }}
+        self.test.response = {'location': '/foo'}
+        with self.assertRaises(AssertionError):
+            self._assert_handler(handler)
+
+    def test_response_headers_regex_path_match(self):
+        handler = core.HeadersResponseHandler()
+        self.test.test_data = {'response_headers': {
+            'location': '//bar//',
+        }}
+        self.test.response = {'location': '/foo/bar/baz'}
+        self._assert_handler(handler)
+
+    def test_response_headers_regex_path_nomatch(self):
+        handler = core.HeadersResponseHandler()
+        self.test.test_data = {'response_headers': {
+            'location': '//bar//',
+        }}
+        self.test.response = {'location': '/foo/foobar/baz'}
+        with self.assertRaises(AssertionError):
+            self._assert_handler(handler)
 
     def test_response_headers_fail_data(self):
         handler = core.HeadersResponseHandler()

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -201,6 +201,46 @@ class HandlersTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self._assert_handler(handler)
 
+    def test_response_json_paths_substitution_regex(self):
+        handler = jsonhandler.JSONHandler()
+        self.test.location = '/foo/bar'
+        self.test.prior = self.test
+        self.test.content_type = "application/json"
+        self.test.test_data = {'response_json_paths': {
+            '$.pathtest': '/$LOCATION/',
+        }}
+        self.test.response_data = {
+            'pathtest': '/foo/bar/baz'
+        }
+        self._assert_handler(handler)
+
+    def test_response_json_paths_substitution_noregex(self):
+        handler = jsonhandler.JSONHandler()
+        self.test.location = '/foo/bar/'
+        self.test.prior = self.test
+        self.test.content_type = "application/json"
+        self.test.test_data = {'response_json_paths': {
+            '$.pathtest': '$LOCATION',
+        }}
+        self.test.response_data = {
+            'pathtest': '/foo/bar/baz'
+        }
+        with self.assertRaises(AssertionError):
+            self._assert_handler(handler)
+
+    def test_response_json_paths_substitution_esc_regex(self):
+        handler = jsonhandler.JSONHandler()
+        self.test.location = '/foo/bar?query'
+        self.test.prior = self.test
+        self.test.content_type = "application/json"
+        self.test.test_data = {'response_json_paths': {
+            '$.pathtest': '/$LOCATION/',
+        }}
+        self.test.response_data = {
+            'pathtest': '/foo/bar?query=value'
+        }
+        self._assert_handler(handler)
+
     def test_response_json_paths_regex_number(self):
         handler = jsonhandler.JSONHandler()
         self.test.content_type = "application/json"
@@ -248,6 +288,36 @@ class HandlersTest(unittest.TestCase):
             'content-type': '/text/plain/',
         }}
         self.test.response = {'content-type': 'text/plain; charset=UTF-8'}
+        self._assert_handler(handler)
+
+    def test_response_headers_substitute_noregex(self):
+        handler = core.HeadersResponseHandler()
+        self.test.location = '/foo/bar/'
+        self.test.prior = self.test
+        self.test.test_data = {'response_headers': {
+            'location': '$LOCATION',
+        }}
+        self.test.response = {'location': '/foo/bar/baz'}
+        with self.assertRaises(AssertionError):
+            self._assert_handler(handler)
+
+    def test_response_headers_substitute_regex(self):
+        handler = core.HeadersResponseHandler()
+        self.test.location = '/foo/bar/'
+        self.test.prior = self.test
+        self.test.test_data = {'response_headers': {
+            'location': '/^$LOCATION/',
+        }}
+        self.test.response = {'location': '/foo/bar/baz'}
+        self._assert_handler(handler)
+
+    def test_response_headers_substitute_esc_regex(self):
+        handler = core.HeadersResponseHandler()
+        self.test.scheme = 'git+ssh'
+        self.test.test_data = {'response_headers': {
+            'location': '/^$SCHEME://.*/',
+        }}
+        self.test.response = {'location': 'git+ssh://example.test'}
         self._assert_handler(handler)
 
     def test_response_headers_noregex_path_match(self):

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -171,7 +171,7 @@ class HandlersTest(unittest.TestCase):
             '$.objects[0].name': '/ow/',
         }}
         self.test.response_data = {
-            'objects': [{'name': 'cow',
+            'objects': [{'name': u'cow\U0001F404',
                          'location': 'barn'},
                         {'name': 'chris',
                          'location': 'house'}]

--- a/gabbi/tests/test_history.py
+++ b/gabbi/tests/test_history.py
@@ -50,6 +50,15 @@ class HistoryTest(unittest.TestCase):
             self.test.test_data)
         self.assertEqual('test_content', header)
 
+    def test_header_replace_with_history_regex(self):
+        self.test.test_data = '/$HISTORY["mytest"].$HEADERS["content-type"]/'
+        self.test.response = {'content-type': 'test+content'}
+        self.test.history["mytest"] = self.test
+
+        header = self.test('test_request').replace_template(
+            self.test.test_data, escape_regex=True)
+        self.assertEqual(r'/test\+content/', header)
+
     def test_response_replace_prior(self):
         self.test.test_data = '$RESPONSE["$.object.name"]'
         json_handler = jsonhandler.JSONHandler()
@@ -64,6 +73,21 @@ class HistoryTest(unittest.TestCase):
         response = self.test('test_request').replace_template(
             self.test.test_data)
         self.assertEqual('test history', response)
+
+    def test_response_replace_prior_regex(self):
+        self.test.test_data = '/$RESPONSE["$.object.name"]/'
+        json_handler = jsonhandler.JSONHandler()
+        self.test.content_type = "application/json"
+        self.test.content_handlers = [json_handler]
+        self.test.prior = self.test
+        self.test.response = {'content-type': 'application/json'}
+        self.test.response_data = {
+            'object': {'name': 'test history.'}
+        }
+
+        response = self.test('test_request').replace_template(
+            self.test.test_data, escape_regex=True)
+        self.assertEqual(r'/test\ history\./', response)
 
     def test_response_replace_with_history(self):
         self.test.test_data = '$HISTORY["mytest"].$RESPONSE["$.object.name"]'
@@ -89,6 +113,15 @@ class HistoryTest(unittest.TestCase):
             self.test.test_data)
         self.assertEqual('test=cookie', cookie)
 
+    def test_cookie_replace_prior_regex(self):
+        self.test.test_data = '/$COOKIE/'
+        self.test.response = {'set-cookie': 'test=cookie?'}
+        self.test.prior = self.test
+
+        cookie = self.test('test_request').replace_template(
+            self.test.test_data, escape_regex=True)
+        self.assertEqual(r'/test\=cookie\?/', cookie)
+
     def test_cookie_replace_history(self):
         self.test.test_data = '$HISTORY["mytest"].$COOKIE'
         self.test.response = {'set-cookie': 'test=cookie'}
@@ -107,6 +140,15 @@ class HistoryTest(unittest.TestCase):
             self.test.test_data)
         self.assertEqual('test_location', location)
 
+    def test_location_replace_prior_regex(self):
+        self.test.test_data = '/$LOCATION/'
+        self.test.location = '..'
+        self.test.prior = self.test
+
+        location = self.test('test_request').replace_template(
+            self.test.test_data, escape_regex=True)
+        self.assertEqual(r'/\.\./', location)
+
     def test_location_replace_history(self):
         self.test.test_data = '$HISTORY["mytest"].$LOCATION'
         self.test.location = 'test_location'
@@ -124,6 +166,15 @@ class HistoryTest(unittest.TestCase):
         url = self.test('test_request').replace_template(
             self.test.test_data)
         self.assertEqual('test_url', url)
+
+    def test_url_replace_prior_regex(self):
+        self.test.test_data = '/$URL/'
+        self.test.url = 'testurl?query'
+        self.test.prior = self.test
+
+        url = self.test('test_request').replace_template(
+            self.test.test_data, escape_regex=True)
+        self.assertEqual(r'/testurl\?query/', url)
 
     def test_url_replace_history(self):
         self.test.test_data = '$HISTORY["mytest"].$URL'


### PR DESCRIPTION
This series fixes a bunch of issues with matching against regular expressions when:

* The output data contains non-ASCII characters
* The regex itself begins or ends with a `/`
* The expression is just a literal single `/`, not a regex
* The expression is a substitution and the substituted values begins and ends with a `/`
* A substitution occurs inside the regex and the substituted data contains characters that have special meaning in a regular expression