### PR TITLE
Allow to load python object from yaml

### DIFF
--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -43,7 +43,7 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
                 response_handlers=None, content_handlers=None,
                 prefix='', require_ssl=False, url=None,
                 inner_fixtures=None, verbose=False,
-                use_prior_test=True):
+                use_prior_test=True, safe_yaml=True):
     """Read YAML files from a directory to create tests.
 
     Each YAML file represents a list of HTTP requests.
@@ -69,6 +69,8 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
                     ``'headers'`` and ``'body'`` are also accepted.
     :param use_prior_test: If ``True``, uses prior test to create ordered
                            sequence of tests
+    :param safe_yaml: If ``True``, recognizes only standard YAML tags and not
+                      Python object
     :type inner_fixtures: List of fixtures.Fixture classes.
     :rtype: TestSuite containing multiple TestSuites (one for each YAML file).
     """
@@ -112,7 +114,8 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
                 % test_file))
         if intercept:
             host = str(uuid.uuid4())
-        suite_dict = utils.load_yaml(yaml_file=test_file)
+        suite_dict = utils.load_yaml(yaml_file=test_file,
+                                     safe=safe_yaml)
         test_base_name = os.path.splitext(os.path.basename(test_file))[0]
         if all_test_base_name:
             test_base_name = '%s_%s' % (all_test_base_name, test_base_name)
@@ -148,7 +151,8 @@ def py_test_generator(test_dir, host=None, port=8001, intercept=None,
                       prefix=None, test_loader_name=None,
                       fixture_module=None, response_handlers=None,
                       content_handlers=None, require_ssl=False, url=None,
-                      metafunc=None, use_prior_test=True):
+                      metafunc=None, use_prior_test=True,
+                      safe_yaml=True):
     """Generate tests cases for py.test
 
     This uses build_tests to create TestCases and then yields them in
@@ -168,7 +172,8 @@ def py_test_generator(test_dir, host=None, port=8001, intercept=None,
                         response_handlers=response_handlers,
                         content_handlers=content_handlers,
                         prefix=prefix, require_ssl=require_ssl,
-                        url=url, use_prior_test=use_prior_test)
+                        url=url, use_prior_test=use_prior_test,
+                        safe_yaml=safe_yaml)
 
     test_list = []
     for test in tests:

--- a/gabbi/runner.py
+++ b/gabbi/runner.py
@@ -89,7 +89,8 @@ def run():
     if not input_files:
         success = run_suite(sys.stdin, handler_objects, host, port,
                             prefix, force_ssl, failfast,
-                            verbosity=verbosity)
+                            verbosity=verbosity,
+                            safe_yaml=args.safe_yaml)
         failure = not success
     else:
         for input_file in input_files:
@@ -99,7 +100,8 @@ def run():
                 success = run_suite(fh, handler_objects, host, port,
                                     prefix, force_ssl, failfast,
                                     data_dir=data_dir,
-                                    verbosity=verbosity, name=name)
+                                    verbosity=verbosity, name=name,
+                                    safe_yaml=args.safe_yaml)
             if not success:
                 failures.append(input_file)
             if not failure:  # once failed, this is considered immutable
@@ -114,9 +116,10 @@ def run():
 
 
 def run_suite(handle, handler_objects, host, port, prefix, force_ssl=False,
-              failfast=False, data_dir='.', verbosity=False, name='input'):
+              failfast=False, data_dir='.', verbosity=False, name='input',
+              safe_yaml=True):
     """Run the tests from the YAML in handle."""
-    data = utils.load_yaml(handle)
+    data = utils.load_yaml(handle, safe=safe_yaml)
     if force_ssl:
         if 'defaults' in data:
             data['defaults']['ssl'] = True
@@ -223,6 +226,14 @@ def _make_argparser():
         dest='verbosity',
         choices=['all', 'body', 'headers'],
         help='Turn on test verbosity for all tests run in this session.'
+    )
+    parser.add_argument(
+        '--unsafe-yaml',
+        dest='safe_yaml',
+        action='store_false',
+        default=True,
+        help='Turn on recognition of Python objects in addition to '
+             'standard YAML tags.'
     )
     return parser
 

--- a/gabbi/tests/gabbits_runner/nan.yaml
+++ b/gabbi/tests/gabbits_runner/nan.yaml
@@ -1,0 +1,8 @@
+tests:
+  - name: test NAN
+    url: /nan
+    method: GET
+    request_headers:
+        content-type: application/json
+    response_json_paths:
+        $.nan: !!python/object:gabbi.tests.util.NanChecker {}

--- a/gabbi/tests/gabbits_unsafe_yaml/nan.yaml
+++ b/gabbi/tests/gabbits_unsafe_yaml/nan.yaml
@@ -1,0 +1,9 @@
+tests:
+  - name: test NAN
+    url: /nan
+    method: GET
+    request_headers:
+        content-type: application/json
+    response_json_paths:
+        $.nan: !NanChecker {}
+        $.nan: !IsNAN

--- a/gabbi/tests/simple_wsgi.py
+++ b/gabbi/tests/simple_wsgi.py
@@ -112,6 +112,11 @@ class SimpleWsgi(object):
                                     query_data['value'][0]})
             start_response('200 OK', [('Content-Type', 'application/json')])
             return [json_data.encode('utf-8')]
+        elif path_info == '/nan':
+            start_response('200 OK', [('Content-Type', 'application/json')])
+            return [json.dumps({
+                "nan": float('nan')
+            }).encode('utf-8')]
 
         start_response('200 OK', headers)
 

--- a/gabbi/tests/test_runner.py
+++ b/gabbi/tests/test_runner.py
@@ -85,6 +85,19 @@ class RunnerTest(unittest.TestCase):
             except SystemExit as err:
                 self.assertFailure(err)
 
+    def test_unsafe_yaml(self):
+        sys.argv = ['gabbi-run', 'http://%s:%s/nan' % (self.host, self.port)]
+
+        sys.argv.append('--unsafe-yaml')
+        sys.argv.append('--')
+        sys.argv.append('gabbi/tests/gabbits_runner/nan.yaml')
+
+        with self.server():
+            try:
+                runner.run()
+            except SystemExit as err:
+                self.assertSuccess(err)
+
     def test_target_url_parsing(self):
         sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port)]
 

--- a/gabbi/tests/test_unsafe_yaml.py
+++ b/gabbi/tests/test_unsafe_yaml.py
@@ -1,0 +1,45 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""A sample test module to exercise the code.
+
+For the sake of exploratory development.
+"""
+
+import os
+
+import yaml
+
+from gabbi import driver
+from gabbi.tests import simple_wsgi
+from gabbi.tests import util
+
+
+TESTS_DIR = 'gabbits_unsafe_yaml'
+
+
+yaml.add_constructor(u'!IsNAN', lambda loader, node: util.NanChecker())
+
+
+def load_tests(loader, tests, pattern):
+    """Provide a TestSuite to the discovery process."""
+    # Set and environment variable for one of the tests.
+    util.set_test_environ()
+
+    prefix = os.environ.get('GABBI_PREFIX')
+    test_dir = os.path.join(os.path.dirname(__file__), TESTS_DIR)
+    return driver.build_tests(test_dir, loader, host=None,
+                              intercept=simple_wsgi.SimpleWsgi,
+                              test_loader_name=__name__,
+                              prefix=prefix,
+                              safe_yaml=False)

--- a/gabbi/tests/util.py
+++ b/gabbi/tests/util.py
@@ -12,7 +12,10 @@
 # under the License.
 """Utility methods shared by some tests."""
 
+import math
 import os
+
+import yaml
 
 
 def set_test_environ():
@@ -27,3 +30,13 @@ def set_test_environ():
     os.environ['FALSE'] = 'false'
     os.environ['STRING'] = 'val'
     os.environ['NULL'] = 'null'
+
+
+class NanChecker(yaml.YAMLObject):
+    yaml_tag = u'!NanChecker'
+
+    def __eq__(self, other):
+        try:
+            return math.isnan(other)
+        except TypeError:
+            return False

--- a/gabbi/utils.py
+++ b/gabbi/utils.py
@@ -99,19 +99,21 @@ def get_colorizer(stream):
         return lambda x, y: y
 
 
-def load_yaml(handle=None, yaml_file=None):
+def load_yaml(handle=None, yaml_file=None, safe=True):
     """Read and parse any YAML file or filehandle.
 
     Let exceptions flow where they may.
 
     If no file or handle is provided, read from STDIN.
     """
+    load = yaml.safe_load if safe else yaml.load
+
     if yaml_file:
         with io.open(yaml_file, encoding='utf-8') as source:
-            return yaml.safe_load(source.read())
+            return load(source.read())
 
     # This will intentionally raise AttributeError if handle is None.
-    return yaml.safe_load(handle.read())
+    return load(handle.read())
 
 
 def not_binary(content_type):


### PR DESCRIPTION
It can be interesting to write custom object to compare values.

For example, I need to ensure an output is equal to .NAN

Because .NAN == .NAN always returns false. We currently can't compare it
with assert_equals().

With the unsafe yaml loader we can register a custom method to check
NAN, for example:

    class IsNAN(object):
        @classmethod
        def constructor(cls, loader, node):
            return cls()

        def __eq__(self, other):
            return numpy.isnan(other)

    yaml.add_constructor(u'!ISNAN', ISNAN.constructor)