### PR TITLE
Run replace template for header keys

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -283,11 +283,11 @@ All of these variables may be used in all of the following fields:
 * ``url``
 * ``query_parameters``
 * ``data``
-* ``request_headers``
+* ``request_headers`` (in both the key and value)
 * ``response_strings``
 * ``response_json_paths`` (in both the key and value, see
   :ref:`json path substitution <json-subs>` for more info)
-* ``response_headers`` (on the value side of the key value pair)
+* ``response_headers`` (in both the key and value)
 * ``response_forbidden_headers``
 * ``count`` and ``delay`` fields of ``poll``
 

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -489,12 +489,18 @@ class HTTPTestCase(testtools.TestCase):
 
         method = test['method'].upper()
         headers = test['request_headers']
+
+        replaced_headers = {}
         for name in headers:
             try:
-                headers[name] = self.replace_template(headers[name])
+                replaced_name = self.replace_template(name)
+                replaced_headers[replaced_name] = self.replace_template(
+                    headers[name]
+                )
             except TypeError as exc:
                 raise exception.GabbiFormatError(
                     'malformed headers in test %s: %s' % (test['name'], exc))
+        headers = replaced_headers
 
         if test['data'] != '':
             body = self._test_data_to_string(

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -478,6 +478,21 @@ class HTTPTestCase(testtools.TestCase):
             self.response_data = None
         self.output = decoded_output
 
+    def _replace_headers_template(self, test_name, headers):
+        replaced_headers = {}
+
+        for name in headers:
+            try:
+                replaced_name = self.replace_template(name)
+                replaced_headers[replaced_name] = self.replace_template(
+                    headers[name]
+                )
+            except TypeError as exc:
+                raise exception.GabbiFormatError(
+                    'malformed headers in test %s: %s' % (test_name, exc))
+
+        return replaced_headers
+
     def _run_test(self):
         """Make an HTTP request and compare the response with expectations."""
         test = self.test_data
@@ -487,20 +502,15 @@ class HTTPTestCase(testtools.TestCase):
         self.url = base_url
         full_url = self._parse_url(base_url)
 
+        # Replace variables in headers with variable values. This includes both
+        # in the header key and the header value.
+        test['request_headers'] = self._replace_headers_template(
+            test['name'], test['request_headers'])
+        test['response_headers'] = self._replace_headers_template(
+            test['name'], test['response_headers'])
+
         method = test['method'].upper()
         headers = test['request_headers']
-
-        replaced_headers = {}
-        for name in headers:
-            try:
-                replaced_name = self.replace_template(name)
-                replaced_headers[replaced_name] = self.replace_template(
-                    headers[name]
-                )
-            except TypeError as exc:
-                raise exception.GabbiFormatError(
-                    'malformed headers in test %s: %s' % (test['name'], exc))
-        headers = replaced_headers
 
         if test['data'] != '':
             body = self._test_data_to_string(

--- a/gabbi/tests/gabbits_runner/header_key.yaml
+++ b/gabbi/tests/gabbits_runner/header_key.yaml
@@ -4,3 +4,5 @@ tests:
     request_headers:
       $SCHEME: some-scheme
     status: 200
+    response_headers:
+      $SCHEME: some-scheme

--- a/gabbi/tests/gabbits_runner/header_key.yaml
+++ b/gabbi/tests/gabbits_runner/header_key.yaml
@@ -1,0 +1,6 @@
+tests:
+  - name: expected success
+    GET: /header_key
+    request_headers:
+      $SCHEME: some-scheme
+    status: 200

--- a/gabbi/tests/simple_wsgi.py
+++ b/gabbi/tests/simple_wsgi.py
@@ -118,10 +118,16 @@ class SimpleWsgi(object):
                 "nan": float('nan')
             }).encode('utf-8')]
         elif path_info == '/header_key':
-            if environ.get('HTTP_HTTP', False):
+            scheme_header = environ.get('HTTP_HTTP', False)
+
+            if scheme_header:
+                headers.append(('HTTP', scheme_header))
                 start_response('200 OK', headers)
             else:
                 start_response('500 SERVER ERROR', headers)
+
+            query_output = json.dumps(query_data)
+            return [query_output.encode('utf-8')]
 
         start_response('200 OK', headers)
 

--- a/gabbi/tests/simple_wsgi.py
+++ b/gabbi/tests/simple_wsgi.py
@@ -117,6 +117,11 @@ class SimpleWsgi(object):
             return [json.dumps({
                 "nan": float('nan')
             }).encode('utf-8')]
+        elif path_info == '/header_key':
+            if environ.get('HTTP_HTTP', False):
+                start_response('200 OK', headers)
+            else:
+                start_response('500 SERVER ERROR', headers)
 
         start_response('200 OK', headers)
 

--- a/gabbi/tests/test_runner.py
+++ b/gabbi/tests/test_runner.py
@@ -98,6 +98,19 @@ class RunnerTest(unittest.TestCase):
             except SystemExit as err:
                 self.assertSuccess(err)
 
+    def test_header_key_variable_substitution(self):
+        sys.argv = [
+            'gabbi-run', 'http://%s:%s/header_key' % (self.host, self.port)]
+
+        sys.argv.append('--')
+        sys.argv.append('gabbi/tests/gabbits_runner/header_key.yaml')
+
+        with self.server():
+            try:
+                runner.run()
+            except SystemExit as err:
+                self.assertSuccess(err)
+
     def test_target_url_parsing(self):
         sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port)]
 


### PR DESCRIPTION
Ref. Substitution not occurring for header key #231 

Run `replace_template` for header keys as well as header values.