### PR TITLE
Move header_key.yaml to intercept tsts

### DIFF
--- a/gabbi/tests/gabbits_intercept/header-key.yaml
+++ b/gabbi/tests/gabbits_intercept/header-key.yaml
@@ -1,5 +1,9 @@
+# Test that header keys run the template handling.
+
 tests:
-  - name: expected success
+
+  - name: header named http
+    verbose: True
     GET: /header_key
     request_headers:
       $SCHEME: some-scheme

--- a/gabbi/tests/test_runner.py
+++ b/gabbi/tests/test_runner.py
@@ -98,19 +98,6 @@ class RunnerTest(unittest.TestCase):
             except SystemExit as err:
                 self.assertSuccess(err)
 
-    def test_header_key_variable_substitution(self):
-        sys.argv = [
-            'gabbi-run', 'http://%s:%s/header_key' % (self.host, self.port)]
-
-        sys.argv.append('--')
-        sys.argv.append('gabbi/tests/gabbits_runner/header_key.yaml')
-
-        with self.server():
-            try:
-                runner.run()
-            except SystemExit as err:
-                self.assertSuccess(err)
-
     def test_target_url_parsing(self):
         sys.argv = ['gabbi-run', 'http://%s:%s/foo' % (self.host, self.port)]
 


### PR DESCRIPTION
As originally written header_key.yaml was exercised by the runner
tests. This worked, but use a bit of extra effort that's not
required. This change moves gabbits_runner/header_key.yaml
to gabbits_intercept/header-key.yaml. This:

* allows the test be run automatically as part of the test_intercept
  routines, without special calling, so the test in test_runner.py
  is removed
* changes the _ to a - to remove a warning that gabbi produces when
  it sees a _ in a yaml file. These can cause issues with test grouping
  so while allowed, are discouraged.