### PR TITLE
Raise GabbiFormatError when headers are None

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -481,15 +481,15 @@ class HTTPTestCase(testtools.TestCase):
     def _replace_headers_template(self, test_name, headers):
         replaced_headers = {}
 
-        for name in headers:
-            try:
+        try:
+            for name in headers:
                 replaced_name = self.replace_template(name)
                 replaced_headers[replaced_name] = self.replace_template(
                     headers[name]
                 )
-            except TypeError as exc:
-                raise exception.GabbiFormatError(
-                    'malformed headers in test %s: %s' % (test_name, exc))
+        except TypeError as exc:
+            raise exception.GabbiFormatError(
+                'malformed headers in test %s: %s' % (test_name, exc))
 
         return replaced_headers
 

--- a/gabbi/tests/test_replacers.py
+++ b/gabbi/tests/test_replacers.py
@@ -18,6 +18,7 @@ import os
 import unittest
 
 from gabbi import case
+from gabbi import exception
 
 
 class EnvironReplaceTest(unittest.TestCase):
@@ -56,3 +57,13 @@ class EnvironReplaceTest(unittest.TestCase):
 
         os.environ['moo'] = "True"
         self.assertEqual(True, http_case._environ_replace(message))
+
+
+class TestReplaceHeaders(unittest.TestCase):
+
+    def test_empty_headers(self):
+        """A None value in headers should cause a GabbiFormatError."""
+        http_case = case.HTTPTestCase('test_request')
+        self.assertRaises(
+                exception.GabbiFormatError,
+                http_case._replace_headers_template, 'foo', None)


### PR DESCRIPTION
It easy in YAML to create an entry which is normally a dict but
ends up with the value of None by making an empty entry:

    - name: foo
      GET: /
      request_headers:
      status: 200

This is something that gabbi has (accidentally) allowed, but should
not as it can lead to inscrutable problems throughout the tests.

So now that there's a convenient place to put it, raise
GabbiFormatError indicating the test where the problem is.

Fixes #236