### PR TITLE
Pass strict=True when creating httpclient

### DIFF
--- a/gabbi/httpclient.py
+++ b/gabbi/httpclient.py
@@ -182,5 +182,5 @@ def get_http(verbose=False, caption=''):
         if verbose == 'headers':
             body = False
         return VerboseHttp(body=body, headers=headers, colorize=colorize,
-                           stream=stream, caption=caption)
-    return Http()
+                           stream=stream, caption=caption, strict=True)
+    return Http(strict=True)


### PR DESCRIPTION
When strict=True, urllib3's PoolManager (and the underlying
ConnectionPool and HTTPConnection) require that the first line
received in an HTTP response be a valid HTTP status line. If
not a BadStatusLine exception is raised. The actual handling
of strictness is within the httplib and http.lib modules
(depending on Python version). In Python 3, strict is ignored
because the library is always strict.

If strict=False (the default) a bad status line will be ignored
and, bizarrely, the status of the response is set to 200,
misleading gabbi. This is because a bad status line is
interpreted as possibly being an HTTP 0.9 response.

Since gabbi has no interest in HTTP 0.9, nor in being mislead
by inaccurate status values, always call strict when creating
the client.

Fixes #239