### PR TITLE
Allow listing of tests with no host configured

### DIFF
--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -83,7 +83,7 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
 
     # Exit immediately if we have no host to access, either via a real host
     # or an intercept.
-    if not bool(host) ^ bool(intercept):
+    if not ((host is not None) ^ bool(intercept)):
         raise AssertionError(
             'must specify exactly one of host or url, or intercept')
 

--- a/gabbi/suitemaker.py
+++ b/gabbi/suitemaker.py
@@ -106,8 +106,10 @@ class TestMaker(object):
         # from a different module.
         if self.test_loader_name:
             klass.__module__ = self.test_loader_name
+        check_host = case.testcase.skipIf(not self.host,
+                                          'No host configured')
 
-        tests = self.loader.loadTestsFromTestCase(klass)
+        tests = self.loader.loadTestsFromTestCase(check_host(klass))
         history[test['name']] = tests._tests[0]
         # Return the first (and only) test in the klass.
         return tests._tests[0]


### PR DESCRIPTION
When creating tests, if the host was empty (and no intercept was provided),
an AssertionError would be raised immediately. This meant that in the case
where no configuration information is available, authors of load_test()
functions had to choose between simply not loading any tests (or
suppressing the exception) and allowing test discovery to fail.

This change allows an empty string to be passed as the host, in which case
the TestCases will be generated (so tests can be listed) but the tests will
be skipped. This will show up in reporting, whereas excluding the tests
from the listing is silent.

If the host, url, and intercept are all None, this will continue to
generate an immediate AssertionError since it is likely due to the caller
simply not passing any of those arguments.

See https://bugs.launchpad.net/heat-tempest-plugin/+bug/1749218 for the initial request.