### PR TITLE
read data from disk improvement

### DIFF
--- a/docs/source/jsonpath.rst
+++ b/docs/source/jsonpath.rst
@@ -78,6 +78,42 @@ or::
 
 Examples like this can be found in one of gabbi's `own tests`_.
 
+When reading from disk you can apply the same JSONPath by adding a ':' to the
+end of your file name. This allows you to store multiple api responses into
+a json file to reduce file management when constructing your tests
+
+.. highlight:: json
+
+Given JSON data as follows::
+
+    {
+        "values": [{
+            "pets": [{
+                "type": "cat",
+                "sound": "meow"
+            }, {
+                "type": "dog",
+                "sound": "woof"
+            }]
+        }, {
+            "people": [{
+                "name": "chris",
+                "id": 1
+            }, {
+                "name": "justin",
+                "id": 2
+            }]
+        }]
+    }
+
+.. highlight:: yaml
+
+You can write your tests like the following::
+
+    response_json_paths:
+        $.pets: <@pets.json
+        $.pets[?type = "cat"].sound: <@values.json:$.values[0].pets[?type = "cat"].sound
+
 There are more JSONPath examples in :doc:`example` and in the
 `jsonpath_rw`_ and `jsonpath_rw_ext`_ documentation.
 

--- a/docs/source/jsonpath.rst
+++ b/docs/source/jsonpath.rst
@@ -79,8 +79,8 @@ or::
 Examples like this can be found in one of gabbi's `own tests`_.
 
 When reading from disk you can apply the same JSONPath by adding a ':' to the
-end of your file name. This allows you to store multiple api responses into
-a json file to reduce file management when constructing your tests
+end of your file name. This allows you to store multiple API responses into
+a JSON file to reduce file management when constructing your tests.
 
 .. highlight:: json
 
@@ -113,6 +113,10 @@ You can write your tests like the following::
     response_json_paths:
         $.pets: <@pets.json
         $.pets[?type = "cat"].sound: <@values.json:$.values[0].pets[?type = "cat"].sound
+
+Although placing more than one API response into a single JSON file may seem
+convenient, keep in mind there is a tradeoff in readability that should not
+be overlooked before implementing this technique.
 
 There are more JSONPath examples in :doc:`example` and in the
 `jsonpath_rw`_ and `jsonpath_rw_ext`_ documentation.

--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -91,8 +91,8 @@ class JSONHandler(base.ContentHandler):
         if isinstance(value, str) and value.startswith('<@'):
             # Do template expansion in the rhs if rhs_path is provided.
             if ':' in value:
-                value, rhs_path = value.split(':')
-                rhs_path = test.replace_template(rhs_path)
+                value, rhs_path = value.split(':$', 1)
+                rhs_path = test.replace_template('$' + rhs_path)
             info = test.load_data_file(value.replace('<@', '', 1))
             info = six.text_type(info, 'UTF-8')
             value = self.loads(info)

--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -88,7 +88,7 @@ class JSONHandler(base.ContentHandler):
                                  '%s' % (path, test.response_data))
 
         # read data from disk if the value starts with '<@'
-        if isinstance(value, str) and value.startswith('<@'):
+        if isinstance(value, six.string_types) and value.startswith('<@'):
             # Do template expansion in the rhs if rhs_path is provided.
             if ':' in value:
                 value, rhs_path = value.split(':$', 1)

--- a/gabbi/tests/gabbits_handlers/values.json
+++ b/gabbi/tests/gabbits_handlers/values.json
@@ -1,0 +1,19 @@
+{
+    "values": [{
+        "pets": [{
+            "type": "cat",
+            "sound": "meow"
+        }, {
+            "type": "dog",
+            "sound": "woof"
+        }]
+    }, {
+        "people": [{
+            "name": "chris",
+            "id": 1
+        }, {
+            "name": "justin",
+            "id": 2
+        }]
+    }]
+}

--- a/gabbi/tests/gabbits_intercept/data-right-side.yaml
+++ b/gabbi/tests/gabbits_intercept/data-right-side.yaml
@@ -1,0 +1,25 @@
+# Test loading expected data from file on disk with JSONPath
+#
+defaults:
+  request_headers:
+      content-type: application/json
+  verbose: True
+
+tests:
+    - name: json encoded value from disk
+      POST: /
+      data: <@data.json
+      response_json_paths:
+          $.foo['bár']: <@data.json:$.foo['bár']
+
+    - name: json parital from disk
+      POST: /
+      data: <@cat.json
+      response_json_paths:
+          $: <@pets.json:$[?type = "cat"]
+
+    - name: json partial both sides
+      POST: /
+      data: <@pets.json
+      response_json_paths:
+          $[?type = "cat"].sound: <@values.json:$.values[0].pets[?type = "cat"].sound

--- a/gabbi/tests/gabbits_intercept/values.json
+++ b/gabbi/tests/gabbits_intercept/values.json
@@ -1,0 +1,19 @@
+{
+    "values": [{
+        "pets": [{
+            "type": "cat",
+            "sound": "meow"
+        }, {
+            "type": "dog",
+            "sound": "woof"
+        }]
+    }, {
+        "people": [{
+            "name": "chris",
+            "id": 1
+        }, {
+            "name": "justin",
+            "id": 2
+        }]
+    }]
+}

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -14,6 +14,7 @@
 """
 
 import json
+import os
 import unittest
 
 from gabbi import case
@@ -267,6 +268,39 @@ class HandlersTest(unittest.TestCase):
             self.assertIn('has incorrect type', str(exc))
             self.assertIn("response_json_paths in 'omega test'",
                           str(exc))
+
+    def test_response_json_paths_from_disk_json_path(self):
+        handler = jsonhandler.JSONHandler()
+        lhs = '$.pets[?type = "cat"].sound'
+        rhs = '$.values[0].pets[?type = "cat"].sound'
+        self.test.test_directory = os.path.dirname(__file__)
+        self.test.test_data = {'response_json_paths': {
+            lhs: '<@gabbits_handlers/values.json:' + rhs,
+        }}
+        self.test.response_data = {
+            "pets": [
+                {"type": "cat", "sound": "meow"},
+                {"type": "dog", "sound": "woof"}
+            ]
+        }
+        self._assert_handler(handler)
+
+    def test_response_json_paths_from_disk_json_path_fail(self):
+        handler = jsonhandler.JSONHandler()
+        lhs = '$.pets[?type = "cat"].sound'
+        rhs = '$.values[0].pets[?type = "bad"].sound'
+        self.test.test_directory = os.path.dirname(__file__)
+        self.test.test_data = {'response_json_paths': {
+            lhs: '<@gabbits_handlers/values.json:' + rhs,
+        }}
+        self.test.response_data = {
+            "pets": [
+                {"type": "cat", "sound": "meow"},
+                {"type": "dog", "sound": "woof"}
+            ]
+        }
+        with self.assertRaises(AssertionError):
+            self._assert_handler(handler)
 
     def test_response_headers(self):
         handler = core.HeadersResponseHandler()


### PR DESCRIPTION
This commit aims to add a new feature that allows a user to specify
a subset of a json file by using the existing JSONPath functionality
by expanding on the read from disk operator '<@'

closes #250