### PR TITLE
Turn of uxsuccess validation in test harness

### DIFF
--- a/gabbi/tests/gabbits_intercept/self.yaml
+++ b/gabbi/tests/gabbits_intercept/self.yaml
@@ -12,11 +12,6 @@ tests:
   url: /
   verbose: True
 
-- name: get simple page xfail uxsuccess
-  xfail: true
-  url: /
-  verbose: True
-
 - name: inheritance of defaults
   response_headers:
       x-gabbi-url: $SCHEME://$NETLOC/cow?alpha=1

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -9,15 +9,14 @@ shopt -u nocasematch
 
 FAILS=12
 
-GREP_FAIL_MATCH="expected failures=$FAILS,"
+GREP_FAIL_MATCH="expected failures=$FAILS"
 GREP_SKIP_MATCH="skipped=$SKIP,"
-GREP_UXSUC_MATCH='unexpected successes=1'
 # This skip is always 2 because the pytest tests don't
 # run the live tests.
 PYTEST_MATCH="$SKIP skipped, $FAILS xfailed"
 
 stestr run && \
-    for match in "${GREP_FAIL_MATCH}" "${GREP_UXSUC_MATCH}" "${GREP_SKIP_MATCH}"; do
+    for match in "${GREP_FAIL_MATCH}" "${GREP_SKIP_MATCH}"; do
         stestr last --subunit | subunit2pyunit 2>&1 | \
             grep "${match}"
     done

--- a/tox.ini
+++ b/tox.ini
@@ -77,9 +77,10 @@ basepython = python2.7
 deps = tox
 commands = -mkdir {envdir}/src
            -rm -r {envdir}/src/*
-           bash -c "curl https://tarballs.openstack.org/nova/nova-master.tar.gz | tar -C {envdir}/src -zxv --strip-components 1 -f - "
+           bash -c "curl https://tarballs.openstack.org/nova/nova-master.tar.gz | tar -C {envdir}/src -zx --strip-components 1 -f - "
            tox -c {envdir}/src -e functional --notest  # ensure a virtualenv is built
-           {envdir}/src/.tox/functional/bin/pip install -U {toxinidir}  # install gabbi
+           # nova shares tox envs so it's just luck that we know the tox dir is different from name
+           {envdir}/src/.tox/py27/bin/pip install -U {toxinidir}  # install gabbi
            tox -c {envdir}/src -e functional test_placement_api
 whitelist_externals =
     mkdir


### PR DESCRIPTION
Because stestr now (correctly) treats uxsuccess as a signal
that the test suite should fail, we can no longer easily
confirm that generating a uxsuccess produces the expected
output, at least not without making some additional tests
outside the normal harness.

That's not worth doing. We are now able to accept and rely
on the fact that stestr does the right thing so we don't
have to have special tests for that.

Fixes: #258