### PR TITLE
Update testing to use python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: python
 services:
   # For Gnocchi
@@ -27,26 +28,30 @@ matrix:
         - env: TOXENV=py27-pytest
         - env: TOXENV=gnocchi
         - env: TOXENV=placement
-        - python: 3.4
-          env: TOXENV=py34
         - python: pypy
           env: TOXENV=pypy
+          dist: trusty
         - python: pypy3
           env: TOXENV=pypy3
+          dist: trusty
         - python: 3.5
           env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
+        - python: 3.7
+          env: TOXENV=py37
         - python: 3.5
           env: TOXENV=py35-pytest
         - python: 3.6
-          env: TOXENV=py36-failskip
-        - python: 3.6
-          env: TOXENV=py36-limit
-        - python: 3.6
-          env: TOXENV=py36-prefix
-        - python: 3.6
-          env: TOXENV=py36
-        - python: 3.6
           env: TOXENV=py36-pytest
+        - python: 3.7
+          env: TOXENV=py37-pytest
+        - python: 3.7
+          env: TOXENV=py37-failskip
+        - python: 3.7
+          env: TOXENV=py37-limit
+        - python: 3.7
+          env: TOXENV=py37-prefix
 
 notifications:
       irc: "chat.freenode.net#gabbi"

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ looks like this::
 See the docs_ for more details on the many features and formats for
 setting request headers and bodies and evaluating responses.
 
-Gabbi is tested with Python 2.7, 3.4, 3.5, 3.6 and pypy.
+Gabbi is tested with Python 2.7, 3.5, 3.6, 3.7 and pypy.
 
 Tests can be run using `unittest`_ style test runners, `pytest`_
 or from the command line with a `gabbi-run`_ script.

--- a/gabbi/tests/test_history.py
+++ b/gabbi/tests/test_history.py
@@ -13,6 +13,7 @@
 """Test History Replacer.
 """
 
+import sys
 import unittest
 
 from gabbi import case
@@ -120,7 +121,10 @@ class HistoryTest(unittest.TestCase):
 
         cookie = self.test('test_request').replace_template(
             self.test.test_data, escape_regex=True)
-        self.assertEqual(r'/test\=cookie\?/', cookie)
+        if sys.version_info[:2] >= (3, 7):
+            self.assertEqual('/test=cookie\?/', cookie)
+        else:
+            self.assertEqual('/test\=cookie\?/', cookie)
 
     def test_cookie_replace_history(self):
         self.test.test_data = '$HISTORY["mytest"].$COOKIE'

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,9 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Topic :: Internet :: WWW/HTTP :: WSGI
     Topic :: Software Development :: Testing
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 1.6
 skipsdist = True
-envlist = py27,py34,py35,py36,pypy,pep8,limit,failskip,docs,py36-prefix,py36-limit,py36-failskip,py27-pytest,py35-pytest,py36-pytest
+envlist = py27,py35,py36,py37,pypy,pep8,limit,failskip,docs,py37-prefix,py37-limit,py37-failskip,py27-pytest,py35-pytest,py36-pytest,py37-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Python 3.7 is common now, so make it the main test version
in tox.ini and update .travis.yml accordingly.

To have 3.7 we need to start using the xenial dist in travis, and
fall back to trusty for pypy.

In python 3.7 re.escape changes from escaping all non-alphanumeric,
to just special characters, requiring a change in test_history
for that version.

Trove classifiers are updated to reflect 3.7 support. Support for
3.4 is removed, not because gabbi doesn't work on 3.4 but because
it is not worth indicating support.