### PR TITLE
extracted placement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
         - env: TOXENV=gnocchi
         - python: 3.7
           env: TOXENV=placement
+          dist: xenial
         - python: 3.4
           env: TOXENV=py34
         - python: pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ matrix:
         - env: TOXENV=pep8
         - env: TOXENV=py27-pytest
         - env: TOXENV=gnocchi
-        - env: TOXENV=placement
+        - python: 3.7
+          env: TOXENV=placement
         - python: 3.4
           env: TOXENV=py34
         - python: pypy

--- a/tox.ini
+++ b/tox.ini
@@ -81,7 +81,7 @@ commands = -mkdir {envdir}/src
            tox -c {envdir}/src -e functional-py37 --notest  # ensure a virtualenv is built
            # nova shares tox envs so it's just luck that we know the tox dir is different from name
            {envdir}/src/.tox/py37/bin/pip install -U {toxinidir}  # install gabbi
-           tox -c {envdir}/src -e functional test_api
+           tox -c {envdir}/src -e functional-py37 test_api
 whitelist_externals =
     mkdir
     curl

--- a/tox.ini
+++ b/tox.ini
@@ -73,15 +73,15 @@ commands = tox -e py27-postgresql-file --notest  # ensure a virtualenv is built
            tox -e py27-postgresql-file gabbi
 
 [testenv:placement]
-basepython = python2.7
+basepython = python3.7
 deps = tox
 commands = -mkdir {envdir}/src
            -rm -r {envdir}/src/*
-           bash -c "curl https://tarballs.openstack.org/nova/nova-master.tar.gz | tar -C {envdir}/src -zx --strip-components 1 -f - "
-           tox -c {envdir}/src -e functional --notest  # ensure a virtualenv is built
+           bash -c "curl https://tarballs.openstack.org/placement/placement-master.tar.gz | tar -C {envdir}/src -zx --strip-components 1 -f - "
+           tox -c {envdir}/src -e functional-py37 --notest  # ensure a virtualenv is built
            # nova shares tox envs so it's just luck that we know the tox dir is different from name
-           {envdir}/src/.tox/py27/bin/pip install -U {toxinidir}  # install gabbi
-           tox -c {envdir}/src -e functional test_placement_api
+           {envdir}/src/.tox/py37/bin/pip install -U {toxinidir}  # install gabbi
+           tox -c {envdir}/src -e functional test_api
 whitelist_externals =
     mkdir
     curl


### PR DESCRIPTION
Update tox.ini and .travis.yml to use openstack/placement instead of openstack/nova when testing gabbi against one its largest consumers. Placement has been extracted from nova.