### PR TITLE
Make use of unsafe yaml forward compatible

### DIFF
--- a/gabbi/utils.py
+++ b/gabbi/utils.py
@@ -104,14 +104,14 @@ def load_yaml(handle=None, yaml_file=None, safe=True):
 
     If no file or handle is provided, read from STDIN.
     """
-    load = yaml.safe_load if safe else yaml.load
+    loader = yaml.SafeLoader if safe else yaml.Loader
 
     if yaml_file:
         with io.open(yaml_file, encoding='utf-8') as source:
-            return load(source.read())
+            return yaml.load(source.read(), Loader=loader)
 
     # This will intentionally raise AttributeError if handle is None.
-    return load(handle.read())
+    return yaml.load(handle.read(), Loader=loader)
 
 
 def not_binary(content_type):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pbr
 pytest
 six
-PyYAML<4.0
+PyYAML
 urllib3>=1.11.0
 jsonpath-rw-ext>=1.0.0
 wsgi-intercept>=1.2.2


### PR DESCRIPTION
The forthcoming 5.x release of PyYMAL changes how unsafe
yaml is managed [1]. The default for gabbi is to safe
load but the option has been present to unsafe load if
code-executing functionality was desired. The way to
achieve that in 5.x and beyond is more explicit than
prior versions.

In this change we adjust the unsafe loading to work with
both 3.x and the as yet unreleased 5.x.

Fixes #266

[1] https://msg.pyyaml.org/load