### PR TITLE
Adapt to introduced by release of pytest5

### DIFF
--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -247,7 +247,7 @@ class HandlersTest(unittest.TestCase):
         handler = jsonhandler.JSONHandler()
         self.test.content_type = "application/json"
         self.test.test_data = {'response_json_paths': {
-            '$.objects[0].name': '/\d+/',
+            '$.objects[0].name': r'/\d+/',
         }}
         self.test.response_data = {
             'objects': [{'name': 99,

--- a/gabbi/tests/test_history.py
+++ b/gabbi/tests/test_history.py
@@ -122,9 +122,9 @@ class HistoryTest(unittest.TestCase):
         cookie = self.test('test_request').replace_template(
             self.test.test_data, escape_regex=True)
         if sys.version_info[:2] >= (3, 7):
-            self.assertEqual('/test=cookie\?/', cookie)
+            self.assertEqual(r'/test=cookie\?/', cookie)
         else:
-            self.assertEqual('/test\=cookie\?/', cookie)
+            self.assertEqual(r'/test\=cookie\?/', cookie)
 
     def test_cookie_replace_history(self):
         self.test.test_data = '$HISTORY["mytest"].$COOKIE'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pbr
-pytest
+pytest<5.0.0
 six
 PyYAML
 urllib3>=1.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ deps = -r{toxinidir}/requirements.txt
 whitelist_externals = rm
 install_command = pip install --no-cache -U {opts} {packages}
 commands =
-    rm -f .testrepository/times.dbm
     stestr run {posargs}
 setenv = GABBI_PREFIX=
 passenv = GABBI_* HOME
@@ -28,7 +27,10 @@ commands = py.test gabbi
 [testenv:py36-pytest]
 commands = py.test gabbi
 
-[testenv:py36-prefix]
+[testenv:py37-pytest]
+commands = py.test gabbi
+
+[testenv:py37-prefix]
 setenv = GABBI_PREFIX=/snoopy
 
 [testenv:pep8]
@@ -43,10 +45,10 @@ commands = {toxinidir}/test-limit.sh
 [testenv:failskip]
 commands = {toxinidir}/test-failskip.sh
 
-[testenv:py36-limit]
+[testenv:py37-limit]
 commands = {toxinidir}/test-limit.sh
 
-[testenv:py36-failskip]
+[testenv:py37-failskip]
 commands = {toxinidir}/test-failskip.sh
 
 [testenv:cover]


### PR DESCRIPTION
pytest 5 currently does not work with the gabbi tests because of:

* deprecation warnings due to `pytest.config` no longer being preferred
* support for python 2 being dropped

While that is resolved, release a version that is `pytest<5.0.0`