### PR TITLE
Allow pytest 5.0.0

### DIFF
--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -159,8 +159,12 @@ def py_test_generator(test_dir, host=None, port=8001, intercept=None,
     a way that pytest can handle.
     """
 
-    import pytest
-    pluginmanager = pytest.config.pluginmanager
+    if metafunc:
+        pluginmanager = metafunc.config.pluginmanager
+    else:
+        import pytest
+        pluginmanager = pytest.config.pluginmanager
+
     pluginmanager.import_plugin('gabbi.pytester')
 
     loader = unittest.TestLoader()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pbr
-pytest<5.0.0
+pytest
 six
 PyYAML
 urllib3>=1.11.0


### PR DESCRIPTION
Get the pytest Config object from the passed in metafunc rather
than from the global pytest.config _if_ metafunc is set.

With this we are able to un-pin pytest and allow 5.0.0.