### PR TITLE
270 replacer casts

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -289,6 +289,27 @@ Any Previous Test
   difficult for humans to read. Take care to optimize for the
   maintainers that will come after you, not yourself.
 
+Casting
+*******
+
+For ``$ENVIRON`` and ``$RESPONSE`` it is possible to attempt to cast the value
+to another type: ``int``, ``float``, ``str``, or ``bool``. If the cast fails
+an exception will be raised and the test will fail.
+
+This functionality only works when the magical variable is the whole value of
+a YAML entry. If the variable is intermixed with other data, an exception will
+be raised and the test will fail.
+
+The format for a cast is to append a ``:`` and the cast type after the
+type of the magical variable. For example::
+
+    $RESPONSE:int['$.some_string_value']
+
+.. warning:: Prior to the introduction of this feature, ``$ENVIRON`` would
+             already do some automatic casting of numbers to ints and floats
+             and the strings ``True`` and ``False`` to booleans. This continues
+             to be the case, but only if no cast is provided.
+
 .. note:: Where a single-quote character, ``'``, is shown in the variables
           above you may also use a double-quote character, ``"``, but in any
           given expression the same character must be used at both ends.

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -406,8 +406,11 @@ class HTTPTestCase(unittest.TestCase):
     def _replacer_regex(key):
         """Compose a regular expression for test template variables."""
         case = HTTPTestCase._history_regex
-        return r"%s\$%s\[(?P<quote>['\"])(?P<arg>.+?)(?P=quote)\]" % (
-            case, key)
+        return (
+            r"%s\$%s(:(?P<cast>\w+))?"
+            r"\[(?P<quote>['\"])(?P<arg>.+?)(?P=quote)\]" % (
+            case, key))
+
 
     @staticmethod
     def _simple_replacer_regex(key):

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -432,9 +432,8 @@ class HTTPTestCase(unittest.TestCase):
         case = HTTPTestCase._history_regex
         return (
             r"%s\$%s(:(?P<cast>\w+))?"
-            r"\[(?P<quote>['\"])(?P<arg>.+?)(?P=quote)\]" % (
-            case, key))
-
+            r"\[(?P<quote>['\"])(?P<arg>.+?)(?P=quote)\]"
+            % (case, key))
 
     @staticmethod
     def _simple_replacer_regex(key):

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -238,7 +238,7 @@ class HTTPTestCase(unittest.TestCase):
         if cast in APPROVED_CASTS:
             return APPROVED_CASTS[cast](value)
         else:
-            raise RuntimeError('Invalid cast %s used in %s' % (
+            raise RuntimeError('Invalid cast <%s> used in: %s' % (
                 cast, message))
 
     def _environ_replace(self, message, escape_regex=False):
@@ -461,6 +461,11 @@ class HTTPTestCase(unittest.TestCase):
         """Replace a regex match with the value from a previous response."""
         response_path = match.group('arg')
         case = match.group('case')
+        self.cast = match.group('cast')
+        if not preserve and self.cast:
+            raise RuntimeError(
+                'Unable to process cast <%s> within message: %s'
+                % (self.cast, match.string))
         if case:
             referred_case = self.history[case]
         else:
@@ -473,6 +478,8 @@ class HTTPTestCase(unittest.TestCase):
         result = replacer_class.replacer(
             referred_case.response_data, response_path)
         if preserve:
+            if self.cast:
+                return self._cast_value(result, match.string)
             return result
         else:
             return six.text_type(result)

--- a/gabbi/tests/gabbits_intercept/casting.yaml
+++ b/gabbi/tests/gabbits_intercept/casting.yaml
@@ -1,0 +1,37 @@
+# Various tests to get casting in replacers working as
+# expected.
+
+
+fixtures:
+    - EnvironFixture
+
+defaults:
+    verbose: True
+    request_headers:
+        content-type: application/json
+        accept: application/json
+
+tests:
+    - name: default casts
+      desc: anything that looks like a number or bool becomes one
+      POST: /
+      data:
+          int: $ENVIRON['INT']
+          float: $ENVIRON['FLOAT']
+          string: $ENVIRON['STR']
+          tbool: $ENVIRON['TBOOL']
+          fbool: $ENVIRON['FBOOL']
+      response_json_paths:
+          int: 1
+          float: 1.5
+          string: 2
+          tbool: true
+          fbool: false
+
+    - name: cast to string
+      POST: /
+      data:
+          string: $ENVIRON:str['STR']
+      response_json_paths:
+          string: "2"
+

--- a/gabbi/tests/gabbits_intercept/casting.yaml
+++ b/gabbi/tests/gabbits_intercept/casting.yaml
@@ -35,3 +35,56 @@ tests:
       response_json_paths:
           string: "2"
 
+    - name: cast to int internal
+      desc: This will fail because the cast is across the entire message "foo ... bar"
+      xfail: true
+      POST: /
+      data:
+          int: foo $ENVIRON:int['INT'] bar
+      response_json_paths:
+          string: "foo 1 bar"
+
+    - name: json set up
+      POST: /
+      data:
+          int: $ENVIRON['INT']
+          float: $ENVIRON['FLOAT']
+          string: $ENVIRON:str['STR']
+          tbool: $ENVIRON['TBOOL']
+          fbool: $ENVIRON['FBOOL']
+      response_json_paths:
+          int: 1
+          float: 1.5
+          string: "2"
+          tbool: true
+          fbool: false
+
+    - name: send casted json
+      POST: /
+      data:
+          casted: $RESPONSE:int['$.string']
+      response_json_paths:
+          casted: 2
+
+    - name: historic casted json
+      POST: /
+      data:
+          casted: $HISTORY['json set up'].$RESPONSE:int['$.string']
+      response_json_paths:
+          casted: 2
+
+    - name: internal json fail
+      xfail: True
+      desc: This produces an expected run time error because casting here is not useful
+      POST: /
+      data:
+          casted: in this $HISTORY['json set up'].$RESPONSE:int['$.string'] is errors
+      response_json_paths:
+          casted: in this 2 is errors
+
+    - name: internal json fine
+      POST: /
+      data:
+          casted: in this $HISTORY['json set up'].$RESPONSE['$.string'] is not errors
+      response_json_paths:
+          casted: in this 2 is not errors

--- a/gabbi/tests/test_intercept.py
+++ b/gabbi/tests/test_intercept.py
@@ -43,6 +43,19 @@ class FixtureTwo(fixture.GabbiFixture):
     pass
 
 
+class EnvironFixture(fixture.GabbiFixture):
+    """Set some stuff in the environment."""
+    # In the shell environment, environment variables are
+    # always strings, so make that explicit here.
+    os.environ['INT'] = "1"
+    os.environ['FLOAT'] = "1.5"
+    # For making sure something that looks like a number stays
+    # a string?
+    os.environ['STR'] = "2"
+    os.environ['TBOOL'] = "True"
+    os.environ['FBOOL'] = "False"
+
+
 class StubResponseHandler(base.ResponseHandler):
     """A sample response handler just to test."""
 

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -7,7 +7,7 @@ shopt -s nocasematch
 [[ "${GABBI_SKIP_NETWORK:-false}" == "true" ]] && SKIP=7 || SKIP=2
 shopt -u nocasematch
 
-FAILS=13
+FAILS=15
 
 GREP_FAIL_MATCH="expected failures=$FAILS"
 GREP_SKIP_MATCH="skipped=$SKIP,"


### PR DESCRIPTION
This is an effort to provide the functionality described in #270 by implementing optional "casts" on the $ENVIRON and $REPLACER replacers by appending a :cast (int, str, bool, float) to the replacer name (e.g., `$ENVIRON:int['FOOBAR']`).

This only works when the replacer is the entirety of the message being replaced:

```yaml
data:
    foo: $ENVIRON:int['FOOBAR']
```

not mixed in:

```yaml
data:
    foo: boom $ENVIRON:int['FOOBAR'] boom
```

We can't do this for two reasons:

* in part, the surrounding context may conflict with the intended value of the cast
* but more, the way the `repl` function in`re.sub` works, they can only return strings, thus the casting has to happen after the re.sub

While the code is present to make it possible to do casts of other replacers, for the moment any cast will be ignored, mostly because it doesn't make sense for most of them.

It _might_, however, make sense for `$COOKIE` so input on that desired.

This isn't done, it needs to be confirmed as having grammatical sense, and it also needs doc update, but I'm putting it up here for some initial feedback on the format and implementation.