### PR TITLE
Drop support for py2 and remove testtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,15 @@
 sudo: false
 dist: xenial
 language: python
-services:
-  # For Gnocchi
-  - docker
 install:
-      - |
-        if [ "$TOXENV" == "gnocchi" ]; then
-            docker pull gnocchixyz/ci-tools:latest
-        else
-            pip install tox
-        fi
+      - pip install tox
 script:
-      - |
-        case "$TOXENV" in
-            gnocchi)
-              docker run -v ~/.cache/pip:/home/tester/.cache/pip -v $(pwd):/home/tester/src gnocchixyz/ci-tools:latest tox -e ${TOXENV}
-              ;;
-            *)
-              tox
-              ;;
-        esac
+      - tox
 matrix:
     include:
-        - env: TOXENV=py27
         - env: TOXENV=pep8
-        - env: TOXENV=py27-pytest
-        - env: TOXENV=gnocchi
         - python: 3.7
           env: TOXENV=placement
-        - python: pypy
-          env: TOXENV=pypy
-          dist: trusty
         - python: pypy3
           env: TOXENV=pypy3
           dist: trusty
@@ -41,6 +19,8 @@ matrix:
           env: TOXENV=py36
         - python: 3.7
           env: TOXENV=py37
+        - python: 3.8
+          env: TOXENV=py38
         - python: 3.5
           env: TOXENV=py35-pytest
         - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
           env: TOXENV=placement
         - python: pypy3
           env: TOXENV=pypy3
-          dist: trusty
         - python: 3.5
           env: TOXENV=py35
         - python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ looks like this::
 See the docs_ for more details on the many features and formats for
 setting request headers and bodies and evaluating responses.
 
-Gabbi is tested with Python 2.7, 3.5, 3.6, 3.7 and pypy.
+Gabbi is tested with Python 3.5, 3.6, 3.7 and pypy3.
 
 Tests can be run using `unittest`_ style test runners, `pytest`_
 or from the command line with a `gabbi-run`_ script.
@@ -84,7 +84,7 @@ Gabbi is set up to be developed and tested using `tox`_ (installed via
 are in the directories ``gabbi/tests/gabbits_*`` and loaded by the file
 ``gabbi/test_*.py``), you call ``tox``::
 
-    tox -epep8,py27,py34
+    tox -epep8,py37
 
 If you have the dependencies installed (or a warmed up
 virtualenv) you can run the tests by hand and exit on the first
@@ -95,7 +95,7 @@ failure::
 Testing can be limited to individual modules by specifying them
 after the tox invocation::
 
-    tox -epep8,py27,py34 -- test_driver test_handlers
+    tox -epep8,py37 -- test_driver test_handlers
 
 If you wish to avoid running tests that connect to internet hosts,
 set ``GABBI_SKIP_NETWORK`` to ``True``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -111,8 +111,6 @@ As a Python package, gabbi is typically installed via pip::
 
     pip install gabbi
 
-(both Python 2 and Python 3 are supported)
-
 You might want to create a virtual environment; an isolated context for
 Python packages, keeping gabbi cleany separated from the rest of your
 system.
@@ -120,14 +118,6 @@ system.
 Python 3 comes with a built-in tool to create virtual environments::
 
     python3 -m venv venv
-    . venv/bin/activate
-
-    pip install gabbi
-
-Alternatively, with Python 2 we can use `virtualenv`_::
-
-    pip install virtualenv
-    virtualenv venv
     . venv/bin/activate
 
     pip install gabbi

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -5,6 +5,17 @@ These are informal release notes for gabbi since version 1.0.0,
 highlighting major features and changes. For more detail see
 the `commit logs`_ on GitHub.
 
+2.0.0
+-----
+
+* Drop support for Python 2. If you need Python 2 support, use an older version.
+* Stop using ``testtools`` and ``fixtures``. These two modules present several
+  difficulties and their maintenance situation suggests those difficulties
+  will not be resolved. Since Python 2 support is being removed, the need for
+  the modules can be removed as well without losing functionality. "Inner
+  fixtures" that use the ``fixtures.Fixture`` interface should continue to
+  work.
+
 1.49.0
 ------
 

--- a/gabbi/__init__.py
+++ b/gabbi/__init__.py
@@ -12,4 +12,4 @@
 # under the License.
 """See gabbi.driver and gabbbi.case."""
 
-__version__ = '1.49.0'
+__version__ = '2.0.0'

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -65,6 +65,8 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
     :param require_ssl: If ``True``, make all tests default to using SSL.
     :param inner_fixtures: A list of ``Fixtures`` to use with each
                            individual test request.
+    :type inner_fixtures: List of classes with setUp and cleanUp methods to
+                          be used as fixtures.
     :param verbose: If ``True`` or ``'all'``, make tests verbose by default
                     ``'headers'`` and ``'body'`` are also accepted.
     :param use_prior_test: If ``True``, uses prior test to create ordered
@@ -74,7 +76,6 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
     :param cert_validate: If ``False`` ssl server certificate will be ignored,
                         further it will not be validated if provided
                         (set cert_reqs=CERT_NONE to the Http object)
-    :type inner_fixtures: List of fixtures.Fixture classes.
     :rtype: TestSuite containing multiple TestSuites (one for each YAML file).
     """
 

--- a/gabbi/suite.py
+++ b/gabbi/suite.py
@@ -71,7 +71,7 @@ class GabbiSuite(unittest.TestSuite):
         # the entire suite is skipped, and the result stream told
         # we're done. If there are no tests (an empty suite) the
         # exception is re-raised.
-        except Exception as exc:
+        except Exception:
             if self._tests:
                 result.addError(self._tests[0], sys.exc_info())
                 for test in self._tests:

--- a/gabbi/suitemaker.py
+++ b/gabbi/suitemaker.py
@@ -19,6 +19,7 @@ The key piece of code is :meth:`test_suite_from_dict`. It produces a
 
 import copy
 import functools
+import unittest
 
 from gabbi import case
 from gabbi.exception import GabbiFormatError
@@ -90,7 +91,7 @@ class TestMaker(object):
         test_method_name = 'test_request'
         test_method = getattr(case.HTTPTestCase, test_method_name)
 
-        @case.testcase.skipIf(self.host == '', 'No host configured')
+        @unittest.skipIf(self.host == '', 'No host configured')
         @functools.wraps(test_method)
         def do_test(*args, **kwargs):
             return test_method(*args, **kwargs)

--- a/gabbi/tests/test_inner_fixture.py
+++ b/gabbi/tests/test_inner_fixture.py
@@ -18,8 +18,6 @@ An "outer" fixture runs once per test suite. An "inner" is per test request.
 import os
 import sys
 
-import fixtures
-
 from gabbi import driver
 # TODO(cdent): test_pytest allows pytest to see the tests this module
 # produces. Without it, the generator will not run. It is a todo because
@@ -45,16 +43,14 @@ class OuterFixture(fixture.GabbiFixture):
         assert COUNT_OUTER == 1
 
 
-class InnerFixture(fixtures.Fixture):
+class InnerFixture(object):
     """Test that setUp is called 3 times."""
 
     def setUp(self):
-        super(InnerFixture, self).setUp()
         global COUNT_INNER
         COUNT_INNER += 1
 
-    def cleanUp(self, raise_first=True):
-        super(InnerFixture, self).cleanUp()
+    def cleanUp(self):
         assert 1 <= COUNT_INNER <= 3
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ certifi
 jsonpath-rw-ext>=1.0.0
 wsgi-intercept>=1.8.1
 colorama
-testtools

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ basepython = python3.7
 deps = tox
 commands = -mkdir {envdir}/src
            -rm -r {envdir}/src/*
-           bash -c "curl https://tarballs.openstack.org/placement/placement-master.tar.gz | tar -C {envdir}/src -zx --strip-components 1 -f - "
+           bash -c "curl -L https://tarballs.opendev.org/openstack/placement/placement-master.tar.gz | tar -C {envdir}/src -zx --strip-components 1 -f - "
            tox -c {envdir}/src -e functional-py37 --notest  # ensure a virtualenv is built
            # nova shares tox envs so it's just luck that we know the tox dir is different from name
            {envdir}/src/.tox/py37/bin/pip install -U {toxinidir}  # install gabbi

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.1.1
 skipsdist = True
-envlist = py27,py35,py36,py37,pypy,pep8,limit,failskip,docs,py37-prefix,py37-limit,py37-failskip,py27-pytest,py35-pytest,py36-pytest,py37-pytest
+envlist = py35,py36,py37,py38,pypy3,pep8,limit,failskip,docs,py37-prefix,py37-limit,py37-failskip,py35-pytest,py36-pytest,py37-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -18,9 +18,6 @@ passenv = GABBI_* HOME
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = {posargs}
-
-[testenv:py27-pytest]
-commands = py.test gabbi
 
 [testenv:py35-pytest]
 commands = py.test gabbi
@@ -40,12 +37,6 @@ deps = hacking
 commands =
     flake8
 
-[testenv:limit]
-commands = {toxinidir}/test-limit.sh
-
-[testenv:failskip]
-commands = {toxinidir}/test-failskip.sh
-
 [testenv:py37-limit]
 commands = {toxinidir}/test-limit.sh
 
@@ -53,6 +44,7 @@ commands = {toxinidir}/test-limit.sh
 commands = {toxinidir}/test-failskip.sh
 
 [testenv:cover]
+basepython = python3
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run --source gabbi --parallel-mode
@@ -66,16 +58,8 @@ commands =
     coverage report
 
 [testenv:pytest-cov]
+basepython = python3
 commands = py.test --cov=gabbi gabbi/tests --cov-config .coveragerc --cov-report html
-
-[testenv:gnocchi]
-basepython = python2.7
-deps = -egit+https://github.com/gnocchixyz/gnocchi#egg=gnocchi
-       tox
-changedir = {envdir}/src/gnocchi
-commands = tox -e py27-postgresql-file --notest  # ensure a virtualenv is built
-           {envdir}/src/gnocchi/.tox/py27-postgresql-file/bin/pip install -U {toxinidir}  # install gabbi
-           tox -e py27-postgresql-file gabbi
 
 [testenv:placement]
 basepython = python3.7


### PR DESCRIPTION
The initial motivation for this change was removing the testtools
library. It has a cyclical dependency with the fixutures module
which makes installing gabbi in some environments (notably bazel)
difficult. Please to fix this problem in the testtools and fixtures
communities have gone unaddressed for _years_ so an effort was
undertaken to remove them.

That work exposed that much of what testtools was doing was masking
over differences in python3 and python3 unittests. Since it is 2020,
choosing to drop support for python2 is a legitimate choice. People
who still need support for python2 can use an earlier version of
gabbi.

To signal that change, the version number has been raised to 2.0.0.

tox, travis config and setup.cfg have been updated accordingly.