### PR TITLE
Declare package as Python3-only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ summary = Declarative HTTP testing library
 description-file = README.rst
 license = Apache-2
 home-page = https://github.com/cdent/gabbi
+python-requires = >=3.5
 classifier =
     Intended Audience :: Developers
     Intended Audience :: Information Technology
@@ -17,6 +18,7 @@ classifier =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3 :: Only
     Topic :: Internet :: WWW/HTTP :: WSGI
     Topic :: Software Development :: Testing
 


### PR DESCRIPTION
Gabbi is no longer compatible with Python2 as it relies on interface of
unittest lib provided by Python3.

Related issue #280