### PR TITLE
Display response body when no content-type

### DIFF
--- a/gabbi/tests/gabbits_intercept/verbosity.yaml
+++ b/gabbi/tests/gabbits_intercept/verbosity.yaml
@@ -1,0 +1,7 @@
+# Testing for https://github.com/cdent/gabbi/issues/282
+
+
+tests:
+    - name: confirm notempty
+      verbose: true
+      GET: /notempty

--- a/gabbi/tests/simple_wsgi.py
+++ b/gabbi/tests/simple_wsgi.py
@@ -128,6 +128,15 @@ class SimpleWsgi(object):
 
             query_output = json.dumps(query_data)
             return [query_output.encode('utf-8')]
+        elif path_info == '/notempty':
+            # This block is used to experiment with verbosity handling.
+            # See: https://github.com/cdent/gabbi/issues/282
+            content_type = query_data.get('content-type', [None])[0]
+            headers = []
+            if content_type:
+                headers.append(('Content-type', content_type))
+            start_response('200 OK', headers)
+            return ['notempty'.encode('utf-8')]
 
         start_response('200 OK', headers)
 

--- a/test-verbosity.sh
+++ b/test-verbosity.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run a test that confirms that a verbose test will output a response body
+# when there is no content-type.
+
+stestr run "intercept.verbosity" | grep '^notempty' >/dev/null

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.1.1
 skipsdist = True
-envlist = py35,py36,py37,py38,pypy3,pep8,limit,failskip,docs,py37-prefix,py37-limit,py37-failskip,py35-pytest,py36-pytest,py37-pytest
+envlist = py35,py36,py37,py38,pypy3,pep8,limit,failskip,docs,py37-prefix,py37-limit,py37-verbosity,py37-failskip,py35-pytest,py36-pytest,py37-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -39,6 +39,9 @@ commands =
 
 [testenv:py37-limit]
 commands = {toxinidir}/test-limit.sh
+
+[testenv:py37-verbosity]
+commands = {toxinidir}/test-verbosity.sh
 
 [testenv:py37-failskip]
 commands = {toxinidir}/test-failskip.sh


### PR DESCRIPTION
When the response has no content-type and verbose is `true`
gabbi was not displaying the response body. This is because
when no content-type is known, it was assuming a binary
content-type. Now it assumes text/plain.

This comes with the risk that in some rare cases verbosity
might spew data all over the screen if there is a very big
or very binary response when no content-type is set. With
luck this will encourage servers to send a content-type.

An external test, in the form of test-verbosity.sh is added.
This was one of several ways of verifying the output.

Addresses #282