### PR TITLE
Be more reslient with pytest fixture start

### DIFF
--- a/gabbi/suite.py
+++ b/gabbi/suite.py
@@ -82,8 +82,9 @@ class GabbiSuite(unittest.TestSuite):
 
         return result
 
-    def start(self, result, tests):
+    def start(self, result, tests=None):
         """Start fixtures when using pytest."""
+        tests = tests or []
         fixtures, intercept, host, port, prefix = self._get_intercept()
 
         self.used_fixtures = []


### PR DESCRIPTION
In some cases no tests will be sent to the start method, so instead
of a positional arg, use a keyword and set it to an empty list if
not present.