### PR TITLE
Make host_info_from_target work with modern urlparse

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,8 @@ jobs:
                   toxenv: py37
                 - python: 3.8
                   toxenv: py38
+                - python: 3.9
+                  toxenv: py39
                 - python: 3.5
                   toxenv: py35-pytest
                 - python: 3.6

--- a/gabbi/tests/test_utils.py
+++ b/gabbi/tests/test_utils.py
@@ -202,14 +202,14 @@ class UtilsHostInfoFromTarget(unittest.TestCase):
 
     def _test_hostport(self, url_or_host, expected_host,
                        provided_prefix=None, expected_port=None,
-                       expected_prefix=None, expected_ssl=False):
+                       expected_prefix='', expected_ssl=False):
         host, port, prefix, ssl = utils.host_info_from_target(
             url_or_host, provided_prefix)
 
         # normalize hosts, they are case insensitive
         self.assertEqual(expected_host.lower(), host.lower())
         # port can be a string or int depending on the inputs
-        self.assertEqual(expected_port, port)
+        self.assertEqual(str(expected_port), str(port))
         self.assertEqual(expected_prefix, prefix)
         self.assertEqual(expected_ssl, ssl)
 

--- a/gabbi/utils.py
+++ b/gabbi/utils.py
@@ -147,26 +147,16 @@ def parse_content_type(content_type, default_charset='utf-8'):
 def host_info_from_target(target, prefix=None):
     """Turn url or host:port and target into test destination."""
     force_ssl = False
+    # If we have a bare host prefix it with a scheme.
+    if '//' not in target and not target.startswith('http'):
+        target = 'http://' + target
+        if prefix:
+            target = target + prefix
     split_url = urlparse.urlparse(target)
 
-    if split_url.scheme:
-        if split_url.scheme == 'https':
-            force_ssl = True
-        return split_url.hostname, split_url.port, split_url.path, force_ssl
-    else:
-        target = target
-        prefix = prefix
-
-    if ':' in target and '[' not in target:
-        host, port = target.rsplit(':', 1)
-    elif ']:' in target:
-        host, port = target.rsplit(':', 1)
-    else:
-        host = target
-        port = None
-    host = host.replace('[', '').replace(']', '')
-
-    return host, port, prefix, force_ssl
+    if split_url.scheme == 'https':
+        force_ssl = True
+    return split_url.hostname, split_url.port, split_url.path, force_ssl
 
 
 def _colorize(color, message):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.1.1
 skipsdist = True
-envlist = py35,py36,py37,py38,pypy3,pep8,limit,failskip,docs,py37-prefix,py37-limit,py37-verbosity,py37-failskip,py35-pytest,py36-pytest,py37-pytest
+envlist = py35,py36,py37,py38,py39,pypy3,pep8,limit,failskip,docs,py37-prefix,py37-limit,py37-verbosity,py37-failskip,py35-pytest,py36-pytest,py37-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
The modern urlparse has changed behavior for parsing
url-like strings that do not have a scheme. Initially
this was added in python 3.7.x but there were issues
with backwards compatibility. It came back with python
3.9.

The fix here addresses the problem by always adding
a scheme if one is not present. Existing styles of
telling gabbi where to go with requests continue
to work.

Python 3.9 is added to the testing configurations.

Fixes #277