### PR TITLE
Update python version support and tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,8 +10,6 @@ jobs:
                   toxenv: pep8
                 - python: 3.7
                   toxenv: placement
-                - python: 3.5
-                  toxenv: py35
                 - python: 3.6
                   toxenv: py36
                 - python: 3.7
@@ -20,18 +18,22 @@ jobs:
                   toxenv: py38
                 - python: 3.9
                   toxenv: py39
-                - python: 3.5
-                  toxenv: py35-pytest
+                - python: pypy3
+                  toxenv: pypy3
                 - python: 3.6
                   toxenv: py36-pytest
                 - python: 3.7
                   toxenv: py37-pytest
-                - python: 3.7
-                  toxenv: py37-failskip
-                - python: 3.7
-                  toxenv: py37-limit
-                - python: 3.7
-                  toxenv: py37-prefix
+                - python: 3.8
+                  toxenv: py38-pytest
+                - python: 3.9
+                  toxenv: py39-pytest
+                - python: 3.8
+                  toxenv: py38-failskip
+                - python: 3.8
+                  toxenv: py38-limit
+                - python: 3.8
+                  toxenv: py38-prefix
         name: ${{ matrix.toxenv }} on Python ${{ matrix.python }}
         steps:
         - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ looks like this::
 See the docs_ for more details on the many features and formats for
 setting request headers and bodies and evaluating responses.
 
-Gabbi is tested with Python 3.5, 3.6, 3.7 and pypy3.
+Gabbi is tested with Python 3.6, 3.7, 3.8, 3.9 and pypy3.
 
 Tests can be run using `unittest`_ style test runners, `pytest`_
 or from the command line with a `gabbi-run`_ script.

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ summary = Declarative HTTP testing library
 description-file = README.rst
 license = Apache-2
 home-page = https://github.com/cdent/gabbi
-python-requires = >=3.5
+python-requires = >=3.6
 classifier =
     Intended Audience :: Developers
     Intended Audience :: Information Technology
@@ -15,9 +15,10 @@ classifier =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
     Topic :: Internet :: WWW/HTTP :: WSGI
     Topic :: Software Development :: Testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.1.1
 skipsdist = True
-envlist = py35,py36,py37,py38,py39,pypy3,pep8,limit,failskip,docs,py37-prefix,py37-limit,py37-verbosity,py37-failskip,py35-pytest,py36-pytest,py37-pytest
+envlist = py36,py37,py38,py39,pypy3,pep8,limit,failskip,docs,py38-prefix,py38-limit,py38-verbosity,py38-failskip,py36-pytest,py37-pytest,py38-pytest,py39-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -19,16 +19,19 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = {posargs}
 
-[testenv:py35-pytest]
-commands = py.test gabbi
-
 [testenv:py36-pytest]
 commands = py.test gabbi
 
 [testenv:py37-pytest]
 commands = py.test gabbi
 
-[testenv:py37-prefix]
+[testenv:py38-pytest]
+commands = py.test gabbi
+
+[testenv:py39-pytest]
+commands = py.test gabbi
+
+[testenv:py38-prefix]
 setenv = GABBI_PREFIX=/snoopy
 
 [testenv:pep8]
@@ -37,14 +40,18 @@ deps = hacking
 commands =
     flake8
 
-[testenv:py37-limit]
+[testenv:py38-limit]
 commands = {toxinidir}/test-limit.sh
 
-[testenv:py37-verbosity]
+[testenv:py38-verbosity]
 commands = {toxinidir}/test-verbosity.sh
 
-[testenv:py37-failskip]
+[testenv:py38-failskip]
 commands = {toxinidir}/test-failskip.sh
+
+# Use pytest when in pypy3 because stestr fails on loading readline.
+[testenv:pypy3]
+commands = py.test gabbi
 
 [testenv:cover]
 basepython = python3


### PR DESCRIPTION
Remove support for py35, add support for 3.9, make limit,
prefix, etc. tests use 3.8. Fix support for pypy3 by using
pytest to run pypy3 tests. Update tox, workflows, trove
classifiers.

(stestr pulls in readline and readline is not working in
pypy3)

Fixes #290