### PR TITLE
Better test name reporting and skipping

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -287,6 +287,7 @@ Any Previous Test
 
 All of these variables may be used in all of the following fields:
 
+* ``skip``
 * ``url``
 * ``query_parameters``
 * ``data``

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -125,6 +125,9 @@ class HTTPTestCase(unittest.TestCase):
         for fixture in self._fixture_cleanups:
             fixture.cleanUp()
 
+    def shortDescription(self):
+        return self.test_base_name + ': ' + self.test_data['name']
+
     def run(self, result=None):
         """Store the current result handler on this test."""
         self.result = result
@@ -139,8 +142,9 @@ class HTTPTestCase(unittest.TestCase):
         if self.has_run:
             return
 
-        if self.test_data['skip']:
-            self.skipTest(self.test_data['skip'])
+        skip = self.replace_template(self.test_data['skip'])
+        if skip:
+            self.skipTest(skip)
 
         if (self.prior and not self.prior.has_run and
                 self.test_data['use_prior_test']):

--- a/gabbi/suitemaker.py
+++ b/gabbi/suitemaker.py
@@ -112,6 +112,7 @@ class TestMaker(object):
                              'prefix': self.prefix,
                              'prior': prior_test,
                              'history': history,
+                             'test_base_name': self.test_base_name,
                              test_method_name: do_test,
                              })
         # We've been asked to, make this test class think it comes


### PR DESCRIPTION
A shortDescription() method is subclassed. The super
would return the doc string on the test method being
run. Setting __doc__ on that method is not allowed,
so shortDescription() is overridden to provide a
nice default:

  <the name of the test file>: <the name of the test>

Also, the `skip` test member may now use substititions.
This allows skipping to be controlled by environment
variables.