### PR TITLE
Constrain how the JSONHandler accepts content-types

### DIFF
--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -38,9 +38,14 @@ class JSONHandler(base.ContentHandler):
 
     @staticmethod
     def accepts(content_type):
-        content_type = content_type.split(';', 1)[0].strip()
+        content_type = content_type.lower()
+        parameters = ''
+        if ';' in content_type:
+            content_type, parameters = content_type.split(';', 1)
+        content_type = content_type.strip()
         return (content_type.endswith('+json') or
-                content_type.startswith('application/json'))
+                content_type == 'application/json'
+                and 'stream' not in parameters)
 
     @classmethod
     def replacer(cls, response_data, match):

--- a/gabbi/handlers/jsonhandler.py
+++ b/gabbi/handlers/jsonhandler.py
@@ -45,7 +45,7 @@ class JSONHandler(base.ContentHandler):
         content_type = content_type.strip()
         return (content_type.endswith('+json') or
                 content_type == 'application/json'
-                and 'stream' not in parameters)
+                and 'stream=' not in parameters)
 
     @classmethod
     def replacer(cls, response_data, match):

--- a/gabbi/tests/gabbits_intercept/self.yaml
+++ b/gabbi/tests/gabbits_intercept/self.yaml
@@ -149,22 +149,6 @@ tests:
   response_json_paths:
       $.data[0]: hello
 
-- name: json home content type is json
-  url: /?data=hello
-  method: GET
-  request_headers:
-      accept: application/json-home
-  response_json_paths:
-      $.data[0]: hello
-
-- name: json content type detection case insensitive
-  url: /?data=hello
-  method: GET
-  request_headers:
-      accept: ApPlIcAtIoN/JsOn-hOmE
-  response_json_paths:
-      $.data[0]: hello
-
 - name: xml derived content type
   desc: +xml types should not work for json paths
   xfail: true

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -472,6 +472,7 @@ class TestJSONHandlerAccept(unittest.TestCase):
             ("text/plain", False),
             ("application/jsonlines", False),
             ("application/json;stream=true", False),
+            ("application/json;streamable=pony", True),
             ("application/stream+json", True),
             ("application/xml", False),
             ("application/json-seq", False),

--- a/gabbi/tests/test_handlers.py
+++ b/gabbi/tests/test_handlers.py
@@ -444,3 +444,39 @@ class HandlersTest(unittest.TestCase):
         # method and then run its tests to confirm.
         test = self.test('test_request')
         handler(test)
+
+
+class TestJSONHandlerAccept(unittest.TestCase):
+    """Test that the json handler accepts function.
+
+    We need to confirm that it returns True and False at the right
+    times. This is somewhat tricky as there are a fair number of
+    MIME-types that include the string "JSON" but aren't, as a
+    whole document, capable of being decoded.
+    """
+
+    def _test_content_type(self, content_type, expected):
+        if expected:
+            self.assertTrue(
+                jsonhandler.JSONHandler.accepts(content_type),
+                "expected %s to be accepted but it was not!" % content_type)
+        else:
+            self.assertFalse(
+                jsonhandler.JSONHandler.accepts(content_type),
+                "expected %s to not be accepted but it was!" % content_type)
+
+    def test_many_content_types(self):
+        cases = [
+            ("application/json", True),
+            ("application/JSON", True),
+            ("text/plain", False),
+            ("application/jsonlines", False),
+            ("application/json;stream=true", False),
+            ("application/stream+json", True),
+            ("application/xml", False),
+            ("application/json-seq", False),
+            ("application/json-home", False),
+        ]
+        for test in cases:
+            with self.subTest(test[0]):
+                self._test_content_type(*test)


### PR DESCRIPTION
Some formats that look like they might be JSON,
based on the media-type in the content-type header
are not actually valid JSON. This presents problems
with tests trying to decode, but being unable to
do so, causing unexpected failures.

These changes update the accepts method in the
JSONHandler to be more specific and adds tests
to cover it.

As part of this some test which showed that we
accept "application/json-home" as valid JSON have
been removed. That media type is not considered
legitimate. See: https://github.com/mnot/I-D/issues/172

Note that this change is an improvement, but it
is not 100% reliable as there is no good way to
be so because the world is complex and ambiguous,
which is part of why #301 was done: to deal with
gaps.

Thanks to @FND for ideas from #298.

Fixes #296