### PR TITLE
More useful error when data cannot be encoded

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -595,8 +595,12 @@ class HTTPTestCase(unittest.TestCase):
                 data = self.replace_template(data)
                 data = dumper_class.dumps(data, test=self)
             else:
-                raise ValueError(
-                    'unable to process data to %s' % content_type)
+                if content_type:
+                    raise ValueError(
+                        'unable to process data to %s' % content_type)
+                else:
+                    raise ValueError(
+                        'no content-type available for processing data')
 
         data = self.replace_template(data)
 

--- a/gabbi/tests/test_data_to_string.py
+++ b/gabbi/tests/test_data_to_string.py
@@ -1,0 +1,54 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+"""Test handling of data field in tests.
+"""
+
+import unittest
+
+from gabbi import case
+from gabbi import handlers
+
+
+class TestDataToString(unittest.TestCase):
+
+    def setUp(self):
+        self.case = case.HTTPTestCase('test_request')
+        self.case.content_handlers = []
+        for handler in handlers.RESPONSE_HANDLERS:
+            h = handler()
+            if hasattr(h, 'content_handler') and h.content_handler:
+                self.case.content_handlers.append(h)
+
+    def testHappyPath(self):
+        data = [{"hi": "low"}, {"yes": "no"}]
+        content_type = 'application/json'
+        body = self.case._test_data_to_string(data, content_type)
+        self.assertEqual('[{"hi": "low"}, {"yes": "no"}]', body)
+
+    def testNoContentType(self):
+        data = [{"hi": "low"}, {"yes": "no"}]
+        content_type = ''
+        with self.assertRaises(ValueError) as exc:
+            self.case._test_data_to_string(data, content_type)
+        self.assertEqual(
+            'no content-type available for processing data',
+            str(exc.exception))
+
+    def testNoHandler(self):
+        data = [{"hi": "low"}, {"yes": "no"}]
+        content_type = 'application/xml'
+        with self.assertRaises(ValueError) as exc:
+            self.case._test_data_to_string(data, content_type)
+        self.assertEqual(
+            'unable to process data to application/xml',
+            str(exc.exception))


### PR DESCRIPTION
The error message returned has been made somewhat
more informative when there is no content-type,
telling the test maker they need to set one.

New tests confirm the three possible cases.

Fixes #257