### PR TITLE
Bump urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pbr
 pytest
 six
 PyYAML
-urllib3>=1.11.0
+urllib3>=1.24.0
 certifi
 jsonpath-rw-ext>=1.0.0
 wsgi-intercept>=1.9.3


### PR DESCRIPTION
The change 1c43e1c85e2082ca5cfcbc924e6e35e3648329b1 introduced usage
of server_hostname but this is available in urllib3>=1.24.
This change updates the version requirement accordingly.

Fixes #307