### PR TITLE
Add yaml-based tests for host header and sni checking

### DIFF
--- a/gabbi/tests/gabbits_intercept/host-header.yaml
+++ b/gabbi/tests/gabbits_intercept/host-header.yaml
@@ -1,0 +1,18 @@
+# Test, against wsgi-intercept, that SNI and host header handling behaves.
+
+tests:
+
+- name: ssl no host
+  ssl: true
+  url: /
+
+- name: ssl with host
+  ssl: true
+  url: /
+  request_headers:
+    host: httpbin.org
+
+- name: host without ssl
+  url: /
+  request_headers:
+    host: httpbin.org

--- a/gabbi/tests/gabbits_live/host-header.yaml
+++ b/gabbi/tests/gabbits_live/host-header.yaml
@@ -1,0 +1,32 @@
+# Test, against httpbin.org that SNI and host header handling behaves.
+
+fixtures:
+  - LiveSkipFixture
+
+
+tests:
+
+- name: ssl no host
+  url: https://httpbin.org/
+
+- name: ssl with host
+  url: https://httpbin.org/
+  request_headers:
+    host: httpbin.org
+
+- name: ssl wrong host
+  desc: This is expected to fail with an error from urllib
+  xfail: true
+  url: https://httpbin.org/
+  request_headers:
+    host: bin.org
+
+- name: host without ssl
+  url: http://httpbin.org
+  request_headers:
+    host: httpbin.org
+
+- name: wrong host without ssl
+  url: http://httpbin.org
+  request_headers:
+    host: bin.org

--- a/test-failskip.sh
+++ b/test-failskip.sh
@@ -7,7 +7,7 @@ shopt -s nocasematch
 [[ "${GABBI_SKIP_NETWORK:-false}" == "true" ]] && SKIP=7 || SKIP=2
 shopt -u nocasematch
 
-FAILS=15
+FAILS=16
 
 GREP_FAIL_MATCH="expected failures=$FAILS"
 GREP_SKIP_MATCH="skipped=$SKIP,"


### PR DESCRIPTION
The addition of server_hostname to the httpclient
PoolManager, without sufficient testing, has revealed
some issues:

* The minimum urllib3 required is too low. server_hostname
  was introduced in 1.24.x
* However, there is a bug [1] in PoolManager when mixing
  schemes in the same pool manager. This is being fixed
  so the minimum urllib3 will need to be higher still.

Tests are added here, and the minimum value for urllib3
will be set when a release is made.

Some of the tests are "live" meaning they require
network, and can be skipped via the live test
fixture if the GABBI_SKIP_NETWORK env variable is
set to "true".

[1] https://github.com/urllib3/urllib3/issues/2534

Fixes #307
Fixes #309