### PR TITLE
Find the hostname for SNI regardless of case used in `request_headers`

### DIFF
--- a/gabbi/suitemaker.py
+++ b/gabbi/suitemaker.py
@@ -81,10 +81,10 @@ class TestMaker(object):
         self._validate_keys(test, test_name)
 
         # Set server hostname in http request if host header is set.
-        if 'request_headers' in test and 'host' in test['request_headers']:
-            hostname = test['request_headers']['host']
-        else:
-            hostname = None
+        hostname = {
+            key.lower(): val for key, val in
+            test.get('request_headers', {}).items()
+        }.get('host', None)
 
         http_class = httpclient.get_http(verbose=test['verbose'],
                                          caption=test['name'],

--- a/gabbi/tests/gabbits_intercept/host-header.yaml
+++ b/gabbi/tests/gabbits_intercept/host-header.yaml
@@ -12,6 +12,12 @@ tests:
   request_headers:
     host: httpbin.org
 
+- name: ssl with capitalised host
+  ssl: true
+  url: /
+  request_headers:
+    Host: httpbin.org
+
 - name: host without ssl
   url: /
   request_headers:


### PR DESCRIPTION
This change ensures that the hostname needed for SNI can be found regardless of the case used for the keys in `request_headers`.