### PR TITLE
Bump the placement tox env version to python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
                 include:
                 - python: 3.x
                   toxenv: pep8
-                - python: 3.7
+                - python: 3.9
                   toxenv: placement
                 - python: 3.6
                   toxenv: py36

--- a/tox.ini
+++ b/tox.ini
@@ -72,15 +72,15 @@ basepython = python3
 commands = py.test --cov=gabbi gabbi/tests --cov-config .coveragerc --cov-report html
 
 [testenv:placement]
-basepython = python3.7
+basepython = python3.9
 deps = tox
 commands = -mkdir {envdir}/src
            -rm -r {envdir}/src/*
            bash -c "curl -L https://tarballs.opendev.org/openstack/placement/placement-master.tar.gz | tar -C {envdir}/src -zx --strip-components 1 -f - "
-           tox -c {envdir}/src -e functional-py37 --notest  # ensure a virtualenv is built
-           # nova shares tox envs so it's just luck that we know the tox dir is different from name
-           {envdir}/src/.tox/py37/bin/pip install -U {toxinidir}  # install gabbi
-           tox -c {envdir}/src -e functional-py37 test_api
+           tox -c {envdir}/src -e functional-py39 --notest  # ensure a virtualenv is built
+           # placement shares tox envs so use the named shared env
+           {envdir}/src/.tox/py39/bin/pip install -U {toxinidir}  # install gabbi
+           tox -c {envdir}/src -e functional-py39 test_api
 whitelist_externals =
     mkdir
     curl


### PR DESCRIPTION
This aligns the version of python tested with the version
tested in the upstream, which should address python
package install conflicts which recently started causing
test failures.