### PR TITLE
Update docs building for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -250,7 +250,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'Gabbi', u'Gabbi Documentation',
-   u'Chris Dent', 'Gabbi', 'One line description of project.',
+   u'Chris Dent', 'Gabbi', 'HTTP API Testing.',
    'Miscellaneous'),
 ]
 


### PR DESCRIPTION
In a month they will start requiring a .readthedocs.yaml file.

Here we add that file, using the default config, modified to point to the correct location for conf.py.

While inspecting conf.py a minor bit of tex(!) configuration was found to be missing.