### PR TITLE
Turn on testing for python 3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,8 @@ jobs:
                   toxenv: py310
                 - python: "3.11"
                   toxenv: py311
+                - python: "3.12"
+                  toxenv: py312
                 - python: pypy-3.8
                   toxenv: pypy3
                 - python: 3.7
@@ -31,6 +33,10 @@ jobs:
                   toxenv: py39-pytest
                 - python: "3.10"
                   toxenv: py310-pytest
+                - python: "3.11"
+                  toxenv: py311-pytest
+                - python: "3.12"
+                  toxenv: py312-pytest
                 - python: 3.9
                   toxenv: py39-failskip
                 - python: 3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ PyYAML
 urllib3>=1.26.9,<2.0.0
 certifi
 jsonpath-rw-ext>=1.0.0
-wsgi-intercept>=1.9.3
+wsgi-intercept>=1.13.0
 colorama

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,12 @@ classifier =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Topic :: Internet :: WWW/HTTP :: WSGI
     Topic :: Software Development :: Testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.1.1
 skipsdist = True
-envlist = pep8,py37,py38,py39,py310,pypy3,pep8,limit,failskip,docs,py39-prefix,py39-limit,py39-verbosity,py39-failskip,py36-pytest,py37-pytest,py38-pytest,py39-pytest,py310-pytest
+envlist = pep8,py37,py38,py39,py310,py311,py312,pypy3,pep8,limit,failskip,docs,py39-prefix,py39-limit,py39-verbosity,py39-failskip,py36-pytest,py37-pytest,py38-pytest,py39-pytest,py310-pytest,py311-pytest,py312-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -32,6 +32,12 @@ commands = py.test gabbi
 commands = py.test gabbi
 
 [testenv:py310-pytest]
+commands = py.test gabbi
+
+[testenv:py311-pytest]
+commands = py.test gabbi
+
+[testenv:py312-pytest]
 commands = py.test gabbi
 
 [testenv:py39-prefix]


### PR DESCRIPTION
This will initially fail until wsgi-intercept is updated for python 3.12 (in progress).