### PR TITLE
Uncap urllib3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pbr
 pytest
 PyYAML
-urllib3>=1.26.9,<2.0.0
+urllib3>=1.26.9
 certifi
 jsonpath-rw-ext>=1.0.0
 wsgi-intercept>=1.13.0


### PR DESCRIPTION
The issue with urllib3 >= 2 was already fixed by [1].

[1] https://github.com/urllib3/urllib3/commit/2459900b10f54326745a597cc1cf2bf8a18f0d56