### PR TITLE
Httpx intercept

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,8 +11,6 @@ jobs:
                 include:
                 - python: 3.x
                   toxenv: pep8
-                - python: 3.8
-                  toxenv: py38
                 - python: 3.9
                   toxenv: py39
                 - python: "3.10"
@@ -23,10 +21,8 @@ jobs:
                   toxenv: py312
                 - python: "3.13"
                   toxenv: py313
-                - python: pypy-3.8
+                - python: pypy-3.10
                   toxenv: pypy3
-                - python: 3.8
-                  toxenv: py38-pytest
                 - python: 3.9
                   toxenv: py39-pytest
                 - python: "3.10"
@@ -37,12 +33,12 @@ jobs:
                   toxenv: py312-pytest
                 - python: "3.13"
                   toxenv: py313-pytest
-                - python: 3.9
-                  toxenv: py39-failskip
-                - python: 3.9
-                  toxenv: py39-limit
-                - python: 3.9
-                  toxenv: py39-prefix
+                - python: "3.13"
+                  toxenv: py313-failskip
+                - python: "3.13"
+                  toxenv: py313-limit
+                - python: "3.13"
+                  toxenv: py313-prefix
         name: ${{ matrix.toxenv }} on Python ${{ matrix.python }}
         steps:
         - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ looks like this::
 See the docs_ for more details on the many features and formats for
 setting request headers and bodies and evaluating responses.
 
-Gabbi is tested with Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and pypy3.
+Gabbi is tested with Python 3.9, 3.10, 3.11, 3.12, 3.13 and pypy3.10.
 
 Tests can be run using `unittest`_ style test runners, `pytest`_
 or from the command line with a `gabbi-run`_ script.

--- a/docs/source/host.rst
+++ b/docs/source/host.rst
@@ -6,9 +6,8 @@ Gabbi intends to preserve the flow and semantics of HTTP interactions
 as much as possible, and every HTTP request needs to be directed at a host
 of some form. Gabbi provides three ways to control this:
 
-* Using `wsgi-intercept`_ to provide a fake socket and ``WSGI``
-  environment on an arbitrary host and port attached to a ``WSGI``
-  application (see `intercept examples`_).
+* Using `WSGITransport` of httpx to provide a ``WSGI`` environment on
+  directly attached to a ``WSGI`` application (see `intercept examples`_).
 * Using fully qualified ``url`` values in the YAML defined tests (see
   `full examples`_).
 * Using a host and (optionally) port defined at test build time (see
@@ -18,15 +17,15 @@ The intercept and live methods are mutually exclusive per test builder,
 but either kind of test can freely intermix fully qualified URLs into the
 sequence of tests in a YAML file.
 
-For test driven development and local tests the intercept style of
-testing lowers test requirements (no web server required) and is fast.
-Interception is performed as part of :doc:`fixtures` processing as the most
-deeply nested fixture. This allows any configuration or database
-setup to be performed prior to the WSGI application being created.
+For Python-based test driven development and local tests the intercept
+style of testing lowers test requirements (no web server required) and
+is fast. Interception is performed as part of the per-test-case http
+client. Configuration or database setup may be performed using
+:doc:`fixtures`.
 
 For the implementation of the above see :meth:`~gabbi.driver.build_tests`.
 
-.. _wsgi-intercept: https://pypi.python.org/pypi/wsgi_intercept
+.. _WSGITransport: https://www.python-httpx.org/advanced/transports/#wsgi-transport
 .. _intercept examples: https://github.com/cdent/gabbi/blob/main/gabbi/tests/test_intercept.py
 .. _full examples: https://github.com/cdent/gabbi/blob/main/gabbi/tests/gabbits_live/google.yaml
 .. _live examples: https://github.com/cdent/gabbi/blob/main/gabbi/tests/test_live.py

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -29,8 +29,6 @@ import unittest
 from unittest import result as unitresult
 import urllib.parse as urlparse
 
-import wsgi_intercept
-
 from gabbi import __version__
 from gabbi import exception
 from gabbi.handlers import base
@@ -492,29 +490,19 @@ class HTTPTestCase(unittest.TestCase):
         redirect=False,
         timeout=30,
     ):
-        """Run the http request and decode output.
-
-        The call to make the request will catch a WSGIAppError from
-        wsgi_intercept so that the real traceback from a catastrophic
-        error in the intercepted app can be examined.
-        """
+        """Run the http request and decode output."""
 
         if 'user-agent' not in (key.lower() for key in headers):
             headers['user-agent'] = "gabbi/%s (Python httpx)" % __version__
 
-        try:
-            response, content = self.http.request(
-                url,
-                method=method,
-                headers=headers,
-                body=body,
-                redirect=redirect,
-                timeout=timeout,
-            )
-        except wsgi_intercept.WSGIAppError as exc:
-            # Extract and re-raise the wrapped exception.
-            raise exc.exception_type(exc.exception_value).with_traceback(
-                   exc.traceback) from None
+        response, content = self.http.request(
+            url,
+            method=method,
+            headers=headers,
+            body=body,
+            redirect=redirect,
+            timeout=timeout,
+        )
 
         # Set headers and location attributes for follow on requests
         self.response = response

--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -14,7 +14,7 @@
 
 The test case encapsulates the request headers and body and expected
 response headers and body. When the test is run an HTTP request is
-made using urllib3. Assertions are made against the response.
+made using httpx. Assertions are made against the response.
 """
 
 from collections import OrderedDict
@@ -500,7 +500,7 @@ class HTTPTestCase(unittest.TestCase):
         """
 
         if 'user-agent' not in (key.lower() for key in headers):
-            headers['user-agent'] = "gabbi/%s (Python urllib3)" % __version__
+            headers['user-agent'] = "gabbi/%s (Python httpx)" % __version__
 
         try:
             response, content = self.http.request(

--- a/gabbi/driver.py
+++ b/gabbi/driver.py
@@ -52,7 +52,8 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
     :param loader: The TestLoader.
     :param host: The host to test against. Do not use with ``intercept``.
     :param port: The port to test against. Used with ``host``.
-    :param intercept: WSGI app factory for wsgi-intercept.
+    :param intercept: WSGI app factory for the httpx.WSGITransport used by
+                      the httpclient.
     :param test_loader_name: Base name for test classes. Use this to align the
                              naming of the tests with other tests in a system.
     :param fixture_module: Python module containing fixture classes.
@@ -158,7 +159,7 @@ def build_tests(path, loader, host=None, port=8001, intercept=None,
 
 
 def py_test_generator(test_dir, host=None, port=8001, intercept=None,
-                      prefix=None, test_loader_name=None,
+                      prefix='', test_loader_name=None,
                       fixture_module=None, response_handlers=None,
                       content_handlers=None, require_ssl=False, url=None,
                       metafunc=None, use_prior_test=True,

--- a/gabbi/httpclient.py
+++ b/gabbi/httpclient.py
@@ -34,7 +34,14 @@ class Http:
         self.extensions = {}
         if 'server_hostname' in kwargs:
             self.extensions['sni_hostname'] = kwargs['server_hostname']
-        self.client = httpx.Client(verify=kwargs.get('cert_validate', True))
+        transport = kwargs.get('intercept')
+        if transport:
+            transport = httpx.WSGITransport(
+                app=transport(), script_name=kwargs.get("prefix", "")
+            )
+        self.client = httpx.Client(
+            transport=transport, verify=kwargs.get("cert_validate", True)
+        )
 
     def request(self, absolute_uri, method, body, headers, redirect, timeout):
         response = self.client.request(
@@ -191,6 +198,8 @@ def get_http(
     caption='',
     cert_validate=True,
     hostname=None,
+    intercept=None,
+    prefix='',
     timeout=30,
 ):
     """Return an ``Http`` class for making requests."""
@@ -199,6 +208,8 @@ def get_http(
             server_hostname=hostname,
             timeout=timeout,
             cert_validate=cert_validate,
+            intercept=intercept,
+            prefix=prefix,
         )
 
     headers = verbose != 'body'
@@ -213,4 +224,6 @@ def get_http(
         server_hostname=hostname,
         timeout=timeout,
         cert_validate=cert_validate,
+        intercept=intercept,
+        prefix=prefix,
     )

--- a/gabbi/suitemaker.py
+++ b/gabbi/suitemaker.py
@@ -90,6 +90,8 @@ class TestMaker:
                                          caption=test['name'],
                                          cert_validate=test['cert_validate'],
                                          hostname=hostname,
+                                         intercept=self.intercept,
+                                         prefix=self.prefix,
                                          timeout=int(test["timeout"]))
         if prior_test:
             history = prior_test.history

--- a/gabbi/tests/external_server.py
+++ b/gabbi/tests/external_server.py
@@ -1,0 +1,32 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import sys
+from wsgiref import simple_server
+
+from gabbi.tests import simple_wsgi
+
+
+def run(host, port):
+    server = simple_server.make_server(
+        host,
+        int(port),
+        simple_wsgi.SimpleWsgi(),
+    )
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    host = sys.argv[1]
+    port = sys.argv[2]
+    run(host, port)

--- a/gabbi/tests/gabbits_intercept/host-header.yaml
+++ b/gabbi/tests/gabbits_intercept/host-header.yaml
@@ -1,4 +1,4 @@
-# Test, against wsgi-intercept, that SNI and host header handling behaves.
+# Test, against intercepted WSGI app, that SNI and host header handling behaves.
 
 tests:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ PyYAML
 httpx
 certifi
 jsonpath-rw-ext>=1.0.0
-wsgi-intercept>=1.13.0
 colorama

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pbr
 pytest
 PyYAML
-urllib3>=1.26.9,<2.0.0
+httpx
 certifi
 jsonpath-rw-ext>=1.0.0
 wsgi-intercept>=1.13.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifier =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.1.1
 skipsdist = True
-envlist = pep8,py38,py39,py310,py311,py312,py313,pypy3,pep8,limit,failskip,docs,py39-prefix,py39-limit,py39-verbosity,py39-failskip,py36-pytest,py38-pytest,py39-pytest,py310-pytest,py311-pytest,py312-pytest,py313-pytest
+envlist = pep8,py39,py310,py311,py312,py313,pypy3,pep8,limit,failskip,docs,py313-prefix,py313-limit,py313-verbosity,py313-failskip,py36-pytest,py39-pytest,py310-pytest,py311-pytest,py312-pytest,py313-pytest
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -22,9 +22,6 @@ commands = {posargs}
 [testenv:py36-pytest]
 commands = py.test gabbi
 
-[testenv:py38-pytest]
-commands = py.test gabbi
-
 [testenv:py39-pytest]
 commands = py.test gabbi
 
@@ -38,9 +35,9 @@ commands = py.test gabbi
 commands = py.test gabbi
 
 [testenv:py313-pytest]
-commands = py.test gabbi
+commands = py.test {posargs} gabbi
 
-[testenv:py39-prefix]
+[testenv:py313-prefix]
 setenv = GABBI_PREFIX=/snoopy
 
 [testenv:pep8]
@@ -49,15 +46,15 @@ deps = hacking
 commands =
     flake8
 
-[testenv:py39-limit]
+[testenv:py313-limit]
 allowlist_externals = {toxinidir}/test-limit.sh
 commands = {toxinidir}/test-limit.sh
 
-[testenv:py39-verbosity]
+[testenv:py313-verbosity]
 allowlist_externals = {toxinidir}/test-verbosity.sh
 commands = {toxinidir}/test-verbosity.sh
 
-[testenv:py39-failskip]
+[testenv:py313-failskip]
 allowlist_externals = {toxinidir}/test-failskip.sh
 commands = {toxinidir}/test-failskip.sh
 


### PR DESCRIPTION
httpx provides a more modern approach to python+http with
a straightforward API that maps cleanly to gabbi/httpclient.py.

It also, in the future, will allow support for http/2.

The change switches out urllib3 from under httpclient,
replacing it with httpx.

It does not address changes required to get interception
of wsgi applications working. httpx provides its own
way of doing interception that is much different from
the old hack of wsgi-intercept. Those changes will be
next.

Replace wsgi-intercept, used in gabbi as a feature
to install the intercept and do http over a monkey-
patched socker.

The replacement is WSGITransport from httpx. This works
in a different way. Instead of monkey-patching, a
different transport is dependency-injected into the
http client. Each gabbi tests has its own client
instance.

Because of this change in concept the diff, though
not especially big, touches several parts of the code.

1. Fixture handling removes use of the wsgi-intecept
   context manager.
2. intercept and prefix are based to httpclient generation.
   intercept signals that the WSGITransport should be
   used.
3. An external server process (in tests/external_server.py)
   is used by tests/test_runner.py so that gabbi-run
   can be tested effectively without wsgi-intercept.
4. Step 3 identified some long present bugs in the
   SimpleWSGI test app to do with reading content
   from POST and PUT operations.
5. Prefix handling and url-generation are different when
   using WSGITransport so simplewsgi has a different way
   of constructing fully qualified URLs. This uses
   removeprefix which is no supported in python 3.8, so
   support for 3.8 is dropped. 3.8 was EOL in 2024.
6. Special tests which had all been depdending on the older
   python 3.9 now use 3.13. This is mostly because that
   made it is easier for cdent to do testing locally, but
   seems good hygiene anyway.
7. pypy3 is upgrade to pypy3.10 as that's what's available
   these days.
8. Docs have tried to be updated but it is likelys something
   has been missed.
9. Some shenanigans with how hostnames are handled in SimpleWSGI
   needed to be reconciled between what a mac does and what a
   github ci node does.

This patch does _not_ try to prepare a release. That will
be later.