### PR TITLE
Fix metadata table in format.rst

### DIFF
--- a/docs/source/format.rst
+++ b/docs/source/format.rst
@@ -86,7 +86,8 @@ Metadata
    * - ``http_version``
      - Sets the protocol version of the HTTP request.
      - defaults to ``1``
-     - If ``2``, the HTTP request will be made using HTTP/2.  Note: HTTP/3 is
+       
+       If ``2``, the HTTP request will be made using HTTP/2.  Note: HTTP/3 is
        not yet supported.
 
 


### PR DESCRIPTION
currently the table describing the format of tests metadata is not rendered - neither by github, nor by main doc site - as the last row has 4 columns instead of 3, effectively hiding this info from people reading the documentation.