### PR TITLE
Handle double response formatters with mixed quotes

### DIFF
--- a/gabbi/case.py
+++ b/gabbi/case.py
@@ -277,7 +277,7 @@ class HTTPTestCase(unittest.TestCase):
         Let KeyError raise if variable not present. Capture
         the 'cast' if any.
         """
-        environ_name = match.group('arg')
+        environ_name = match.group('arg1') or match.group('arg2')
         self.cast = match.group('cast')
         return os.environ[environ_name]
 
@@ -293,7 +293,7 @@ class HTTPTestCase(unittest.TestCase):
 
     def _cookie_replacer(self, match):
         """Replace a regex match with the cookie of a previous response."""
-        case = match.group('case')
+        case = match.group('case1') or match.group('case2')
         if case:
             referred_case = self.history[case]
         else:
@@ -316,8 +316,8 @@ class HTTPTestCase(unittest.TestCase):
 
     def _header_replacer(self, match):
         """Replace a regex match with the value of a prior header."""
-        header_key = match.group('arg')
-        case = match.group('case')
+        header_key = match.group('arg1') or match.group('arg2')
+        case = match.group('case1') or match.group('case2')
         if case:
             referred_case = self.history[case]
         else:
@@ -346,7 +346,7 @@ class HTTPTestCase(unittest.TestCase):
 
     def _url_replacer(self, match):
         """Replace a regex match with the value of a previous url."""
-        case = match.group('case')
+        case = match.group('case1') or match.group('case2')
         if case:
             referred_case = self.history[case]
         else:
@@ -365,7 +365,7 @@ class HTTPTestCase(unittest.TestCase):
 
     def _location_replacer(self, match):
         """Replace a regex match with the value of a previous location."""
-        case = match.group('case')
+        case = match.group('case1') or match.group('case2')
         if case:
             referred_case = self.history[case]
         else:
@@ -424,7 +424,13 @@ class HTTPTestCase(unittest.TestCase):
                                     parsed_url.path, query_string, ''))
 
     _history_regex = (
-        r"(?:\$HISTORY\[(?P<quote1>['\"])(?P<case>.+?)(?P=quote1)\]\.)??"
+        r"(?:\$HISTORY"
+        r"("
+        r"\['(?P<case1>[^']+?)'\]"
+        "|"
+        r'\["(?P<case2>[^"]+?)"\]'
+        r")"
+        r"\.)??"
     )
 
     @staticmethod
@@ -433,7 +439,11 @@ class HTTPTestCase(unittest.TestCase):
         case = HTTPTestCase._history_regex
         return (
             r"%s\$%s(:(?P<cast>\w+))?"
-            r"\[(?P<quote>['\"])(?P<arg>.+?)(?P=quote)\]"
+            r"("
+            r"\['(?P<arg1>[^']+?)'\]"
+            "|"
+            r'\["(?P<arg2>[^"]+?)"\]'
+            r")"
             % (case, key))
 
     @staticmethod
@@ -459,8 +469,8 @@ class HTTPTestCase(unittest.TestCase):
 
     def _response_replacer(self, match, preserve=False):
         """Replace a regex match with the value from a previous response."""
-        response_path = match.group('arg')
-        case = match.group('case')
+        response_path = match.group('arg1') or match.group('arg2')
+        case = match.group('case1') or match.group('case2')
         self.cast = match.group('cast')
         if not preserve and self.cast:
             raise RuntimeError(

--- a/gabbi/tests/gabbits_intercept/doubleresponse.yaml
+++ b/gabbi/tests/gabbits_intercept/doubleresponse.yaml
@@ -1,0 +1,26 @@
+# Use double of the same formatter, some with mixed quotes
+
+tests:
+- name: post some json
+  url: /posterchild
+  request_headers:
+      content-type: application/json
+  data:
+    baseURL: $SCHEME://$NETLOC/posterchild
+  method: POST
+  response_json_paths:
+    baseURL: $SCHEME://$NETLOC/posterchild
+
+- name: generate that url
+  desc: This would fail because of regex issues without post 4.1.0 changes
+  verbose: true
+  GET: $RESPONSE['$.baseURL']$RESPONSE['$.baseURL']
+
+- name: generate another url
+  desc: This would fail because of regex issues without post 4.1.0 changes
+  verbose: true
+  GET: $HISTORY['post some json'].$RESPONSE["$.baseURL"]$HISTORY['post some json'].$RESPONSE["$.baseURL"]
+
+- name: generate yet another url
+  verbose: true
+  GET: $HISTORY["post some json"].$RESPONSE['$.baseURL']$HISTORY['post some json'].$RESPONSE["$.baseURL"]

--- a/gabbi/tests/gabbits_intercept/json-left-side.yaml
+++ b/gabbi/tests/gabbits_intercept/json-left-side.yaml
@@ -34,4 +34,4 @@ tests:
 - name: check key and value
   GET: /jsonator?key=$ENVIRON['ONE']&value=10
   response_json_paths:
-      $.["$ENVIRON['ONE']"]: $RESPONSE['$['1']']
+      $.["$ENVIRON['ONE']"]: $RESPONSE['$["1"]']


### PR DESCRIPTION
Prior to these changes a test entry like:

  url: $RESPONSE['$.json.path']$RESPONSE['$.json.otherpath']

would experience a parse error as the extracted jsonpath would include portions of the 2nd $RESPONSE string.

This turns out to be because of a greedy regex.

What's interesting and confusing is that the regex, as written, was supposed to be non-greedy already, but it wasn't working correctly.

Further, trying to fix it while maintaining the use of named groups and backreferences did not work.

The result is that we now do slighly more post-processing on slight more complex regexes which might match on arg1 or arg2 (replacers) and case1 or case2 (history indicators) instead of arg and case.

Even with this, there is now one prior test, in
json-left-side.yaml, that had to be changed in order to work properly with the new regexes.

Unless we can come up with something clever, we may need to accept this test change, which is probably fine because the case was very corner.